### PR TITLE
Add message edit and delete lifecycle hooks

### DIFF
--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -412,6 +412,32 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
             self.log.error(f"Failed to resolve attachment {attachment_id}: {e}")
             return None
 
+    async def on_message_edited(self, message: Message) -> None:
+        """
+        Called when a previously processed message is edited by the user.
+
+        The default implementation re-processes the message by calling
+        ``process_message()``.  Subclasses may override this to implement
+        custom edit handling (e.g. regenerating a response, updating context).
+
+        Args:
+            message: The message after the edit, with updated body.
+        """
+        await self.process_message(message)
+
+    async def on_message_deleted(self, message: Message) -> None:
+        """
+        Called when a message is soft-deleted by the user.
+
+        The default implementation is a no-op.  Subclasses may override this
+        to clean up resources associated with the deleted message (e.g.
+        removing a response, clearing conversation history entries).
+
+        Args:
+            message: The deleted message (with ``deleted=True``).
+        """
+        pass
+
     def shutdown(self) -> None:
         """
         Shuts the persona down. This method should:

--- a/jupyter_ai_persona_manager/extension.py
+++ b/jupyter_ai_persona_manager/extension.py
@@ -134,6 +134,12 @@ class PersonaManagerExtension(ExtensionApp):
 
         # Register persona manager callbacks with router
         self.router.observe_chat_msg(room_id, persona_manager.on_chat_message)
+
+        # Register edit/delete callbacks if the router supports them
+        if hasattr(self.router, 'observe_msg_edit'):
+            self.router.observe_msg_edit(room_id, persona_manager.on_chat_message_edited)
+        if hasattr(self.router, 'observe_msg_delete'):
+            self.router.observe_msg_delete(room_id, persona_manager.on_chat_message_deleted)
     
     def _init_persona_manager(
         self, room_id: str, ychat: "YChat"

--- a/jupyter_ai_persona_manager/tests/test_message_lifecycle.py
+++ b/jupyter_ai_persona_manager/tests/test_message_lifecycle.py
@@ -1,0 +1,116 @@
+"""
+Tests for message edit and delete lifecycle hooks.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, Mock, MagicMock, patch
+from jupyterlab_chat.models import Message
+from traitlets.config import LoggingConfigurable
+from jupyter_ai_persona_manager.base_persona import BasePersona, PersonaDefaults
+
+
+class ConcretePersona(BasePersona):
+    """Minimal concrete persona for testing."""
+
+    @property
+    def defaults(self):
+        return PersonaDefaults(
+            name="Test",
+            description="Test persona",
+            avatar_path="/test.svg",
+            system_prompt="You are a test persona.",
+        )
+
+    async def process_message(self, message: Message):
+        pass
+
+
+class StubParent(LoggingConfigurable):
+    """Minimal parent satisfying the Configurable trait requirement."""
+    base_url = "/"
+
+
+@pytest.fixture
+def mock_ychat():
+    ychat = MagicMock()
+    ychat.awareness = MagicMock()
+    ychat.set_user = Mock()
+    return ychat
+
+
+@pytest.fixture
+def stub_parent():
+    return StubParent()
+
+
+def _make_persona(cls, parent, ychat):
+    """Create a persona with PersonaAwareness heartbeat patched out."""
+    with patch(
+        "jupyter_ai_persona_manager.base_persona.PersonaAwareness"
+    ) as MockAwareness:
+        MockAwareness.return_value = MagicMock()
+        return cls(parent=parent, ychat=ychat)
+
+
+@pytest.fixture
+def persona(mock_ychat, stub_parent):
+    return _make_persona(ConcretePersona, stub_parent, mock_ychat)
+
+
+class TestOnMessageEdited:
+    """Test BasePersona.on_message_edited lifecycle hook."""
+
+    @pytest.mark.asyncio
+    async def test_default_calls_process_message(self, persona):
+        """Default on_message_edited delegates to process_message."""
+        persona.process_message = AsyncMock()
+        msg = Message(id="1", body="edited text", sender="user", time=123)
+
+        await persona.on_message_edited(msg)
+
+        persona.process_message.assert_awaited_once_with(msg)
+
+    @pytest.mark.asyncio
+    async def test_override_custom_behavior(self, mock_ychat, stub_parent):
+        """Subclasses can override on_message_edited with custom logic."""
+        edit_log = []
+
+        class CustomPersona(ConcretePersona):
+            async def on_message_edited(self, message):
+                edit_log.append(message.id)
+
+        persona = _make_persona(CustomPersona, stub_parent, mock_ychat)
+        msg = Message(id="msg-42", body="new text", sender="user", time=123)
+
+        await persona.on_message_edited(msg)
+
+        assert edit_log == ["msg-42"]
+
+
+class TestOnMessageDeleted:
+    """Test BasePersona.on_message_deleted lifecycle hook."""
+
+    @pytest.mark.asyncio
+    async def test_default_is_noop(self, persona):
+        """Default on_message_deleted does nothing."""
+        msg = Message(id="1", body="text", sender="user", time=123, deleted=True)
+
+        # Should not raise
+        await persona.on_message_deleted(msg)
+
+    @pytest.mark.asyncio
+    async def test_override_custom_behavior(self, mock_ychat, stub_parent):
+        """Subclasses can override on_message_deleted with custom logic."""
+        delete_log = []
+
+        class CustomPersona(ConcretePersona):
+            async def on_message_deleted(self, message):
+                delete_log.append(message.id)
+
+        persona = _make_persona(CustomPersona, stub_parent, mock_ychat)
+        msg = Message(id="msg-99", body="text", sender="user", time=123, deleted=True)
+
+        await persona.on_message_deleted(msg)
+
+        assert delete_log == ["msg-99"]


### PR DESCRIPTION
## Summary

- Adds `on_message_edited(message)` and `on_message_deleted(message)` lifecycle hooks to `BasePersona`
- Adds routing methods to `PersonaManager` that dispatch edit/delete events to the correct personas
- Wires new router observers in the extension (with `hasattr` guard for backward compat)

## Motivation

When a user edits or deletes a chat message, personas currently have no way to react. This PR adds lifecycle hooks that enable personas to:

- **Re-process** an edited message (default behavior for edits — delegates to `process_message`)
- **Clean up** when a message is deleted (default no-op — subclasses can override)

Depends on [jupyter-ai-contrib/jupyter-ai-router#23](https://github.com/jupyter-ai-contrib/jupyter-ai-router/pull/23) for the `observe_msg_edit` / `observe_msg_delete` router methods. The `hasattr` guard in `extension.py` ensures this works with older router versions too.

## Changes

| File | What changed |
|-|-|
| `base_persona.py` | New `on_message_edited` (default: re-process) and `on_message_deleted` (default: no-op) methods |
| `persona_manager.py` | New `on_chat_message_edited`, `on_chat_message_deleted`, `_resolve_target_personas` methods |
| `extension.py` | Register edit/delete observers with `hasattr` guard |
| `tests/test_message_lifecycle.py` | 4 new tests: default edit delegates to process_message, custom edit override, default delete no-op, custom delete override |

## Test plan

- [x] All 34 tests pass (30 existing + 4 new)
- [x] Default `on_message_edited` correctly delegates to `process_message`
- [x] Default `on_message_deleted` is a no-op
- [x] Subclasses can override both hooks with custom behavior
- [x] Extension wiring is backward-compatible (works without router edit/delete support)
- [ ] Manual integration test with jupyter-ai-router#23