### PR TITLE
Re-raise exceptions in stream_message() after logging

### DIFF
--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -300,6 +300,7 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
                 f"Persona '{self.name}' encountered an exception printed below when attempting to stream output."
             )
             self.log.exception(e)
+            raise
         finally:
             self.awareness.set_local_state_field("isWriting", False)
 


### PR DESCRIPTION
`stream_message()` catches exceptions and logs them, but never re-raises. This means any error handling that callers put in their `process_message()` implementations is dead code — the exception just disappears and execution continues with partial or empty state.

I ran into this when a rate limit error from the LLM provider silently killed the chat with no feedback to the user. The persona's `process_message()` had proper error handling that would have shown an error message, but it never triggered because `stream_message()` swallowed the exception.

I'm not sure why this wasn't the default behavior to begin with — the `finally` block already handles the cleanup (`isWriting` flag), so the `raise` is safe. Callers are expected to handle exceptions themselves (that's why they have `try/except` blocks around `stream_message()` calls).

One-line change: bare `raise` after `self.log.exception(e)`.