### PR TITLE
[DRAFT] Personas based on .md file with YAML front matter

### DIFF
--- a/jupyter_ai_persona_manager/__init__.py
+++ b/jupyter_ai_persona_manager/__init__.py
@@ -9,6 +9,7 @@ except ImportError:
     __version__ = "dev"
 
 from .base_persona import BasePersona, PersonaDefaults
+from .markdown_persona import MarkdownFrontmatter, MarkdownPersona, create_markdown_persona_class
 from .persona_manager import PersonaManager, PersonaRequirementsUnmet
 from .persona_awareness import PersonaAwareness
 from .mcp_server_models import McpSettings, McpServerHttp, McpServerStdio

--- a/jupyter_ai_persona_manager/markdown_persona.py
+++ b/jupyter_ai_persona_manager/markdown_persona.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+import yaml
+from pydantic import BaseModel
+
+from .base_persona import BasePersona, PersonaDefaults
+
+if TYPE_CHECKING:
+    from jupyterlab_chat.models import Message
+    from jupyterlab_chat.ychat import YChat
+
+# Path to the default avatar SVG shipped with this package
+_DEFAULT_AVATAR_PATH = str(Path(__file__).parent / "static" / "default_avatar.svg")
+
+
+class MarkdownFrontmatter(BaseModel):
+    """Parsed YAML frontmatter from a markdown persona file."""
+
+    name: str
+    description: str = ""
+    target_persona: Optional[str] = None
+    """
+    Entry point name or class name of the persona class to inherit from.
+    For example, ``ClaudeCodePersona`` would resolve to the
+    ``ClaudeCodePersona`` entry point registered under the
+    ``jupyter_ai.personas`` group.
+
+    When omitted (``None``), the markdown persona inherits from whatever
+    persona class is configured as the default persona in
+    ``PersonaManager.default_persona_id``.
+    """
+    avatar_path: Optional[str] = None
+
+    # Limitation: `tools` is parsed but not acted on. The codebase currently
+    # has no built-in tool-use abstraction -- each Python persona brings its
+    # own. A future iteration would map tool names to concrete implementations
+    # and use litellm's function-calling API.
+    tools: list[str] = []
+
+    # Limitation: `mcp_servers` references are parsed but no MCP server
+    # connections are established. BasePersona.get_mcp_settings() can read the
+    # MCP config, but wiring MCP tools into litellm function-calling is
+    # deferred.
+    mcp_servers: list[str] = []
+
+    slash_commands: set[str] = set("*")
+
+
+def parse_markdown_persona(md_path: str) -> tuple[MarkdownFrontmatter, str]:
+    """
+    Parse a markdown persona file into its YAML frontmatter and body.
+
+    The file must begin with a ``---`` delimiter, followed by YAML, followed
+    by a closing ``---`` delimiter. Everything after the closing delimiter is
+    the system prompt body (markdown).
+
+    Args:
+        md_path: Absolute path to the ``.md`` file.
+
+    Returns:
+        A tuple of ``(frontmatter, system_prompt_body)``.
+
+    Raises:
+        ValueError: If the file does not contain valid ``---`` delimiters.
+        pydantic.ValidationError: If the YAML does not match the schema.
+    """
+    text = Path(md_path).read_text(encoding="utf-8")
+
+    if not text.startswith("---"):
+        raise ValueError(
+            f"Markdown persona file must start with '---' delimiter: {md_path}"
+        )
+
+    # Find the closing delimiter (skip the first '---')
+    close_idx = text.find("---", 3)
+    if close_idx == -1:
+        raise ValueError(
+            f"Markdown persona file is missing closing '---' delimiter: {md_path}"
+        )
+
+    yaml_block = text[3:close_idx].strip()
+    body = text[close_idx + 3:].strip()
+
+    raw = yaml.safe_load(yaml_block)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"YAML frontmatter must be a mapping, got {type(raw).__name__}: {md_path}"
+        )
+
+    frontmatter = MarkdownFrontmatter(**raw)
+    return frontmatter, body
+
+
+def create_markdown_persona_class(target_class: type[BasePersona]) -> type:
+    """
+    Dynamically create a ``MarkdownPersona`` class that inherits from
+    *target_class*.
+
+    The returned class overrides identity and configuration properties
+    (``id``, ``defaults``, ``_get_system_prompt``) so that values come from
+    the ``.md`` file, while message-processing behaviour is inherited from
+    *target_class*.
+    """
+
+    class MarkdownPersona(target_class):  # type: ignore[misc]
+        """
+        A persona defined by a markdown file with YAML frontmatter.
+
+        The frontmatter specifies name, description, target persona, and
+        optional avatar.  The markdown body becomes the system prompt.
+        Message processing is inherited from the *target_class* resolved at
+        load time.
+        """
+
+        def __init__(
+            self,
+            *args,
+            md_path: str,
+            ychat: "YChat",
+            **kwargs,
+        ):
+            # Parse the markdown file *before* calling super().__init__(),
+            # which accesses self.defaults (and therefore needs
+            # _frontmatter / _body).
+            self._md_path = md_path
+            self._frontmatter, self._body = parse_markdown_persona(md_path)
+
+            # Resolve avatar_path: relative paths are resolved against the
+            # .md file's directory; absent paths use the default avatar
+            # shipped with this package.
+            if self._frontmatter.avatar_path is not None:
+                avatar = Path(self._frontmatter.avatar_path)
+                if not avatar.is_absolute():
+                    avatar = Path(md_path).parent / avatar
+                self._resolved_avatar_path = str(avatar.resolve())
+            else:
+                self._resolved_avatar_path = _DEFAULT_AVATAR_PATH
+
+            super().__init__(*args, ychat=ychat, **kwargs)
+
+        @property
+        def id(self) -> str:
+            """
+            Returns a unique ID for this markdown persona.
+
+            Uses ``md`` as the "package" segment to distinguish from Python
+            personas. The filename stem ensures uniqueness within the
+            directory.
+            """
+            return f"jupyter-ai-personas::md::{Path(self._md_path).stem}"
+
+        @property
+        def defaults(self) -> PersonaDefaults:
+            return PersonaDefaults(
+                name=self._frontmatter.name,
+                description=self._frontmatter.description,
+                avatar_path=self._resolved_avatar_path,
+                system_prompt=self._body,
+                slash_commands=self._frontmatter.slash_commands,
+            )
+
+        def _get_system_prompt(self) -> str:
+            """Return the markdown body as the system prompt."""
+            return self._body
+
+        async def process_message(self, message: "Message") -> None:
+            """
+            Process a message by delegating to the target persona's
+            implementation.
+
+            If this class was created with ``BasePersona`` as the target
+            (i.e. the ``target_persona`` could not be resolved), an error
+            message is sent to the chat instead.
+            """
+            if target_class is BasePersona:
+                self.send_message(
+                    "This persona's `target_persona` could not be resolved "
+                    "to an installed persona class. Please check the "
+                    "frontmatter and ensure the referenced persona package "
+                    "is installed."
+                )
+                return
+
+            return await super().process_message(message)
+
+    return MarkdownPersona
+
+
+# Default concrete class backed by BasePersona.  Used as a fallback when
+# ``target_persona`` cannot be resolved to an installed entry-point class.
+MarkdownPersona = create_markdown_persona_class(BasePersona)

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -21,6 +21,11 @@ from traitlets.config import LoggingConfigurable
 from .base_persona import BasePersona
 from .directories import find_dot_dir, find_workspace_dir
 from .handlers import build_avatar_cache
+from .markdown_persona import (
+    MarkdownPersona,
+    create_markdown_persona_class,
+    parse_markdown_persona,
+)
 from .mcp_server_models import McpSettings
 
 if TYPE_CHECKING:
@@ -232,7 +237,14 @@ class PersonaManager(LoggingConfigurable):
             )
             return
 
-        self._local_persona_classes = load_from_dir(personas_subdir, self.log)
+        py_personas = load_from_dir(personas_subdir, self.log)
+        md_personas = load_markdown_personas_from_dir(
+            personas_subdir,
+            self.log,
+            ep_persona_classes=PersonaManager._ep_persona_classes,
+            default_persona_id=self.default_persona_id,
+        )
+        self._local_persona_classes = py_personas + md_personas
 
     def _init_personas(self) -> dict[str, BasePersona]:
         """
@@ -266,9 +278,11 @@ class PersonaManager(LoggingConfigurable):
                 self._display_persona_error_message(item)
                 continue
             try:
+                extra_kwargs = item.get("kwargs", {})
                 persona = Persona(
                     parent=self,
                     ychat=self.ychat,
+                    **extra_kwargs,
                 )
             except Exception:
                 tb_str = traceback.format_exc()
@@ -664,6 +678,146 @@ def load_from_dir(dir: str, log: Logger) -> list[dict]:
             sys.path.remove(dir)
 
     return persona_classes
+
+
+def find_markdown_persona_files(dir: str) -> list[str]:
+    """Find markdown persona files in a directory.
+
+    Unlike ``find_persona_files``, this does **not** require "persona" in the
+    filename -- any ``.md`` file whose stem does not start with ``_`` or ``.``
+    is considered a markdown persona definition.
+    """
+    if not os.path.exists(dir):
+        return []
+
+    try:
+        all_md_files = glob(os.path.join(dir, "*.md"))
+        md_files = []
+        for f in all_md_files:
+            stem = Path(f).stem
+            if not (stem.startswith("_") or stem.startswith(".")):
+                md_files.append(f)
+        return md_files
+    except Exception:
+        return []
+
+
+def load_markdown_personas_from_dir(
+    dir: str,
+    log: Logger,
+    ep_persona_classes: list[dict] | None = None,
+    default_persona_id: str | None = None,
+) -> list[dict]:
+    """
+    Load markdown persona definitions from ``.md`` files in a directory.
+
+    Each valid markdown file produces a dict entry whose ``persona_class`` is
+    a dynamically-created subclass of the target persona (resolved via
+    *ep_persona_classes*).  If the target cannot be resolved, a fallback
+    ``MarkdownPersona(BasePersona)`` is used instead and a warning is logged.
+    Invalid files produce error entries with a ``traceback``.
+    """
+    persona_entries: list[dict] = []
+
+    md_files = find_markdown_persona_files(dir)
+    if not md_files:
+        return persona_entries
+
+    log.info(
+        f"Loading markdown persona files from {dir}: "
+        f"{[Path(f).name for f in md_files]}"
+    )
+
+    for md_file in md_files:
+        try:
+            # Validate that the file parses correctly
+            frontmatter, _ = parse_markdown_persona(md_file)
+
+            # Resolve target_persona to an installed persona class.
+            # If target_persona is not specified, derive the target from
+            # the default persona ID.
+            target_name = frontmatter.target_persona
+            if target_name is None and default_persona_id:
+                # Extract class name from ID format:
+                # "jupyter-ai-personas::{package}::{ClassName}"
+                parts = default_persona_id.split("::")
+                if len(parts) >= 3:
+                    target_name = parts[-1]
+                    log.info(
+                        f"  - No target_persona specified for '{md_file}'; "
+                        f"using default persona class '{target_name}'."
+                    )
+
+            resolved_class = _resolve_target_persona(
+                target_name, ep_persona_classes, log
+            ) if target_name else None
+
+            if resolved_class is not None:
+                persona_class = create_markdown_persona_class(resolved_class)
+            else:
+                log.warning(
+                    f"  - Could not resolve target_persona "
+                    f"'{target_name}' for '{md_file}'; "
+                    f"falling back to BasePersona."
+                )
+                persona_class = MarkdownPersona
+
+            persona_entries.append(
+                {
+                    "module": md_file,
+                    "persona_class": persona_class,
+                    "traceback": None,
+                    "kwargs": {"md_path": md_file},
+                }
+            )
+            log.info(f"  - Validated markdown persona file '{md_file}'")
+        except Exception:
+            tb_str = traceback.format_exc()
+            log.exception(
+                f"Unable to parse markdown persona from '{md_file}', "
+                f"exception details printed below.\n{tb_str}"
+            )
+            persona_entries.append(
+                {
+                    "module": md_file,
+                    "persona_class": None,
+                    "traceback": tb_str,
+                }
+            )
+
+    return persona_entries
+
+
+def _resolve_target_persona(
+    target_name: str,
+    ep_persona_classes: list[dict] | None,
+    log: Logger,
+) -> type | None:
+    """
+    Look up *target_name* among the loaded entry-point persona classes.
+
+    Returns the persona class if found, or ``None`` if unresolved.
+    """
+    if not ep_persona_classes:
+        return None
+
+    for ep in ep_persona_classes:
+        persona_class = ep.get("persona_class")
+        if persona_class is None:
+            continue
+
+        # Match against entry point name OR the class name itself
+        ep_name = ep.get("module", "")
+        class_name = persona_class.__name__
+
+        if target_name in (ep_name, class_name):
+            log.info(
+                f"  - Resolved target_persona '{target_name}' to "
+                f"{class_name}"
+            )
+            return persona_class
+
+    return None
 
 
 def get_first_word(input_str: str) -> str | None:

--- a/jupyter_ai_persona_manager/static/default_avatar.svg
+++ b/jupyter_ai_persona_manager/static/default_avatar.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#6366f1"/>
+  <path d="M20 28a4 4 0 1 1 8 0 4 4 0 0 1-8 0Zm16 0a4 4 0 1 1 8 0 4 4 0 0 1-8 0Z" fill="#fff"/>
+  <path d="M22 40c0-1.1.9-2 2-2h16a2 2 0 0 1 2 2v0a6 6 0 0 1-6 6H28a6 6 0 0 1-6-6v0Z" fill="#fff"/>
+  <rect x="14" y="14" width="36" height="28" rx="6" stroke="#fff" stroke-width="2" fill="none"/>
+  <path d="M26 14V10m12 4V10" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/jupyter_ai_persona_manager/tests/conftest.py
+++ b/jupyter_ai_persona_manager/tests/conftest.py
@@ -30,10 +30,13 @@ def mock_logger():
 
 @pytest.fixture
 def mock_ychat():
-    """Create a mock YChat instance."""
-    # Import at runtime to avoid circular import
-    from jupyterlab_chat.ychat import YChat
-    mock = Mock(spec=YChat)
+    """Create a mock YChat instance.
+
+    Uses a plain Mock rather than ``Mock(spec=YChat)`` to avoid a circular
+    import triggered by ``jupyter_ydoc`` entry-point loading when
+    ``jupyterlab_chat.ychat`` is first imported at fixture setup time.
+    """
+    mock = Mock()
     mock.get_id.return_value = "test-chat-id"
     mock.set_user = Mock()
     mock.add_message = Mock(return_value="msg-123")

--- a/jupyter_ai_persona_manager/tests/test_markdown_persona.py
+++ b/jupyter_ai_persona_manager/tests/test_markdown_persona.py
@@ -1,0 +1,436 @@
+"""
+Tests for markdown-based persona definitions with YAML frontmatter.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import ValidationError
+from traitlets.config import LoggingConfigurable
+
+from jupyter_ai_persona_manager.markdown_persona import (
+    MarkdownFrontmatter,
+    MarkdownPersona,
+    _DEFAULT_AVATAR_PATH,
+    create_markdown_persona_class,
+    parse_markdown_persona,
+)
+from jupyter_ai_persona_manager.persona_manager import (
+    find_markdown_persona_files,
+    load_markdown_personas_from_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_MD = """\
+---
+name: Test Bot
+description: A test persona
+target_persona: TestTargetPersona
+---
+You are a helpful assistant.
+"""
+
+MINIMAL_MD = """\
+---
+name: Minimal
+target_persona: TestTargetPersona
+---
+"""
+
+
+def _write_md(dir_path: Path, filename: str, content: str) -> Path:
+    p = dir_path / filename
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# TestParseMarkdownPersona
+# ---------------------------------------------------------------------------
+
+
+class TestParseMarkdownPersona:
+    """Tests for the parse_markdown_persona function."""
+
+    def test_valid_parsing(self, tmp_dir):
+        md_file = _write_md(tmp_dir, "bot.md", VALID_MD)
+        fm, body = parse_markdown_persona(str(md_file))
+
+        assert fm.name == "Test Bot"
+        assert fm.description == "A test persona"
+        assert fm.target_persona == "TestTargetPersona"
+        assert body == "You are a helpful assistant."
+
+    def test_missing_name_raises_validation_error(self, tmp_dir):
+        content = """\
+---
+target_persona: SomePersona
+---
+body
+"""
+        md_file = _write_md(tmp_dir, "no_name.md", content)
+        with pytest.raises(ValidationError):
+            parse_markdown_persona(str(md_file))
+
+    def test_missing_target_persona_defaults_to_none(self, tmp_dir):
+        content = """\
+---
+name: No Target
+---
+body
+"""
+        md_file = _write_md(tmp_dir, "no_target.md", content)
+        fm, body = parse_markdown_persona(str(md_file))
+        assert fm.target_persona is None
+        assert fm.name == "No Target"
+        assert body == "body"
+
+    def test_optional_fields_default(self, tmp_dir):
+        md_file = _write_md(tmp_dir, "minimal.md", MINIMAL_MD)
+        fm, body = parse_markdown_persona(str(md_file))
+
+        assert fm.description == ""
+        assert fm.avatar_path is None
+        assert fm.tools == []
+        assert fm.mcp_servers == []
+        assert fm.slash_commands == {"*"}
+        assert body == ""
+
+    def test_tools_and_mcp_servers_parsed(self, tmp_dir):
+        content = """\
+---
+name: Tooled
+target_persona: SomePersona
+tools:
+  - read_file
+  - list_files
+mcp_servers:
+  - my-server
+---
+prompt
+"""
+        md_file = _write_md(tmp_dir, "tooled.md", content)
+        fm, _ = parse_markdown_persona(str(md_file))
+
+        assert fm.tools == ["read_file", "list_files"]
+        assert fm.mcp_servers == ["my-server"]
+
+    def test_empty_body(self, tmp_dir):
+        md_file = _write_md(tmp_dir, "empty.md", MINIMAL_MD)
+        _, body = parse_markdown_persona(str(md_file))
+        assert body == ""
+
+    def test_malformed_yaml_raises(self, tmp_dir):
+        content = """\
+---
+name: [invalid yaml
+---
+body
+"""
+        md_file = _write_md(tmp_dir, "bad_yaml.md", content)
+        with pytest.raises(Exception):
+            parse_markdown_persona(str(md_file))
+
+    def test_missing_opening_delimiter_raises(self, tmp_dir):
+        content = "name: No Delimiters\n---\nbody"
+        md_file = _write_md(tmp_dir, "no_open.md", content)
+        with pytest.raises(ValueError, match="must start with '---'"):
+            parse_markdown_persona(str(md_file))
+
+    def test_missing_closing_delimiter_raises(self, tmp_dir):
+        content = "---\nname: No Close\n"
+        md_file = _write_md(tmp_dir, "no_close.md", content)
+        with pytest.raises(ValueError, match="missing closing '---'"):
+            parse_markdown_persona(str(md_file))
+
+    def test_non_mapping_yaml_raises(self, tmp_dir):
+        content = """\
+---
+- just
+- a
+- list
+---
+body
+"""
+        md_file = _write_md(tmp_dir, "list_yaml.md", content)
+        with pytest.raises(ValueError, match="must be a mapping"):
+            parse_markdown_persona(str(md_file))
+
+
+# ---------------------------------------------------------------------------
+# TestFindMarkdownPersonaFiles
+# ---------------------------------------------------------------------------
+
+
+class TestFindMarkdownPersonaFiles:
+    """Tests for find_markdown_persona_files function."""
+
+    def test_empty_directory(self, tmp_dir):
+        result = find_markdown_persona_files(str(tmp_dir))
+        assert result == []
+
+    def test_finds_md_files(self, tmp_dir):
+        _write_md(tmp_dir, "helper.md", VALID_MD)
+        _write_md(tmp_dir, "coder.md", VALID_MD)
+
+        result = find_markdown_persona_files(str(tmp_dir))
+        names = [Path(f).name for f in result]
+
+        assert "helper.md" in names
+        assert "coder.md" in names
+
+    def test_skips_underscore_and_dot_prefixed(self, tmp_dir):
+        _write_md(tmp_dir, "_draft.md", VALID_MD)
+        _write_md(tmp_dir, ".hidden.md", VALID_MD)
+        _write_md(tmp_dir, "visible.md", VALID_MD)
+
+        result = find_markdown_persona_files(str(tmp_dir))
+        names = [Path(f).name for f in result]
+
+        assert "visible.md" in names
+        assert "_draft.md" not in names
+        assert ".hidden.md" not in names
+
+    def test_nonexistent_directory(self):
+        result = find_markdown_persona_files("/nonexistent/path")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestLoadMarkdownPersonasFromDir
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMarkdownPersonasFromDir:
+    """Tests for load_markdown_personas_from_dir function."""
+
+    def test_valid_md_returns_entry(self, tmp_dir, mock_logger):
+        _write_md(tmp_dir, "helper.md", VALID_MD)
+
+        result = load_markdown_personas_from_dir(str(tmp_dir), mock_logger)
+
+        assert len(result) == 1
+        # Without ep_persona_classes, falls back to MarkdownPersona(BasePersona)
+        assert result[0]["persona_class"] is MarkdownPersona
+        assert result[0]["traceback"] is None
+        assert result[0]["kwargs"]["md_path"].endswith("helper.md")
+
+    def test_resolved_target_uses_dynamic_class(self, tmp_dir, mock_logger):
+        """When target_persona matches an entry point, a dynamic class is created."""
+        from jupyter_ai_persona_manager.base_persona import BasePersona
+
+        class FakeTargetPersona(BasePersona):
+            @property
+            def defaults(self):
+                return None
+
+            async def process_message(self, message):
+                pass
+
+        _write_md(tmp_dir, "helper.md", VALID_MD)
+        ep_classes = [
+            {"module": "TestTargetPersona", "persona_class": FakeTargetPersona, "traceback": None}
+        ]
+
+        result = load_markdown_personas_from_dir(str(tmp_dir), mock_logger, ep_persona_classes=ep_classes)
+
+        assert len(result) == 1
+        assert result[0]["persona_class"] is not MarkdownPersona
+        assert issubclass(result[0]["persona_class"], FakeTargetPersona)
+        assert result[0]["traceback"] is None
+
+    def test_invalid_md_returns_error_entry(self, tmp_dir, mock_logger):
+        bad_content = """\
+---
+description: missing name and target_persona
+---
+body
+"""
+        _write_md(tmp_dir, "bad.md", bad_content)
+
+        result = load_markdown_personas_from_dir(str(tmp_dir), mock_logger)
+
+        assert len(result) == 1
+        assert result[0]["persona_class"] is None
+        assert result[0]["traceback"] is not None
+
+    def test_no_target_persona_uses_default_persona_id(self, tmp_dir, mock_logger):
+        """When target_persona is omitted, the default persona class is used."""
+        from jupyter_ai_persona_manager.base_persona import BasePersona
+
+        class DefaultTargetPersona(BasePersona):
+            @property
+            def defaults(self):
+                return None
+
+            async def process_message(self, message):
+                pass
+
+        no_target_md = """\
+---
+name: No Target Bot
+description: A bot with no explicit target
+---
+You are a helpful bot.
+"""
+        _write_md(tmp_dir, "no_target.md", no_target_md)
+        ep_classes = [
+            {"module": "some_ep", "persona_class": DefaultTargetPersona, "traceback": None}
+        ]
+
+        result = load_markdown_personas_from_dir(
+            str(tmp_dir),
+            mock_logger,
+            ep_persona_classes=ep_classes,
+            default_persona_id="jupyter-ai-personas::some_pkg::DefaultTargetPersona",
+        )
+
+        assert len(result) == 1
+        assert result[0]["persona_class"] is not MarkdownPersona
+        assert issubclass(result[0]["persona_class"], DefaultTargetPersona)
+        assert result[0]["traceback"] is None
+
+    def test_no_target_persona_no_default_falls_back_to_base(self, tmp_dir, mock_logger):
+        """When target_persona is omitted and no default_persona_id, falls back to BasePersona."""
+        no_target_md = """\
+---
+name: Fallback Bot
+---
+prompt
+"""
+        _write_md(tmp_dir, "fallback.md", no_target_md)
+
+        result = load_markdown_personas_from_dir(str(tmp_dir), mock_logger)
+
+        assert len(result) == 1
+        assert result[0]["persona_class"] is MarkdownPersona
+        assert result[0]["traceback"] is None
+
+    def test_empty_dir_returns_empty_list(self, tmp_dir, mock_logger):
+        result = load_markdown_personas_from_dir(str(tmp_dir), mock_logger)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestMarkdownPersona
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownPersona:
+    """Tests for the MarkdownPersona class."""
+
+    def _make_persona(self, tmp_dir, mock_ychat, content=VALID_MD, filename="bot.md"):
+        md_file = _write_md(tmp_dir, filename, content)
+        parent = LoggingConfigurable()
+        parent.base_url = "/"  # type: ignore[attr-defined]
+        with patch(
+            "jupyter_ai_persona_manager.persona_awareness.asyncio.create_task"
+        ):
+            persona = MarkdownPersona(
+                parent=parent,
+                ychat=mock_ychat,
+                md_path=str(md_file),
+            )
+        return persona
+
+    def test_id_derived_from_filename(self, tmp_dir, mock_ychat):
+        persona = self._make_persona(tmp_dir, mock_ychat, filename="my_helper.md")
+        assert persona.id == "jupyter-ai-personas::md::my_helper"
+
+    def test_defaults_property(self, tmp_dir, mock_ychat):
+        persona = self._make_persona(tmp_dir, mock_ychat)
+        defaults = persona.defaults
+
+        assert defaults.name == "Test Bot"
+        assert defaults.description == "A test persona"
+        assert defaults.system_prompt == "You are a helpful assistant."
+
+    def test_avatar_path_default(self, tmp_dir, mock_ychat):
+        """When avatar_path is omitted, the default avatar is used."""
+        persona = self._make_persona(tmp_dir, mock_ychat)
+        assert persona.defaults.avatar_path == _DEFAULT_AVATAR_PATH
+
+    def test_avatar_path_relative(self, tmp_dir, mock_ychat):
+        """Relative avatar_path is resolved against the .md file's directory."""
+        # Create a dummy avatar file
+        avatar_file = tmp_dir / "icon.svg"
+        avatar_file.write_text("<svg/>")
+
+        content = """\
+---
+name: Bot
+target_persona: TestTargetPersona
+avatar_path: icon.svg
+---
+prompt
+"""
+        persona = self._make_persona(tmp_dir, mock_ychat, content=content)
+        assert persona.defaults.avatar_path == str(avatar_file.resolve())
+
+    def test_avatar_path_absolute(self, tmp_dir, mock_ychat):
+        """Absolute avatar_path is used as-is."""
+        content = f"""\
+---
+name: Bot
+target_persona: TestTargetPersona
+avatar_path: /absolute/path/icon.svg
+---
+prompt
+"""
+        persona = self._make_persona(tmp_dir, mock_ychat, content=content)
+        assert persona.defaults.avatar_path == "/absolute/path/icon.svg"
+
+    @pytest.mark.asyncio
+    async def test_get_system_prompt_returns_body(self, tmp_dir, mock_ychat):
+        """_get_system_prompt returns the markdown body."""
+        persona = self._make_persona(tmp_dir, mock_ychat)
+        assert persona._get_system_prompt() == "You are a helpful assistant."
+
+
+# ---------------------------------------------------------------------------
+# TestCreateMarkdownPersonaClass
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMarkdownPersonaClass:
+    """Tests for the create_markdown_persona_class factory."""
+
+    def test_inherits_from_target(self, tmp_dir, mock_ychat):
+        """The created class should be a subclass of the target class."""
+        from jupyter_ai_persona_manager.base_persona import BasePersona
+
+        DynamicClass = create_markdown_persona_class(BasePersona)
+        assert issubclass(DynamicClass, BasePersona)
+
+    def test_factory_creates_distinct_classes(self):
+        """Each call to the factory should create a distinct class."""
+        from jupyter_ai_persona_manager.base_persona import BasePersona
+
+        ClassA = create_markdown_persona_class(BasePersona)
+        ClassB = create_markdown_persona_class(BasePersona)
+        # Same name but different class objects
+        assert ClassA is not ClassB
+
+    def test_process_message_inherited_from_target(self, tmp_dir, mock_ychat):
+        """process_message should come from the target class, not BasePersona."""
+        from jupyter_ai_persona_manager.base_persona import BasePersona
+
+        class FakePersona(BasePersona):
+            """A fake persona class to test inheritance."""
+
+            _process_called = False
+
+            @property
+            def defaults(self):
+                return None  # Not used in this test
+
+            async def process_message(self, message):
+                FakePersona._process_called = True
+
+        DynamicClass = create_markdown_persona_class(FakePersona)
+        assert issubclass(DynamicClass, FakePersona)

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -2,13 +2,20 @@
 Test the persona manager functionality.
 """
 
+import asyncio
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
-from jupyter_ai_persona_manager.base_persona import BasePersona
-from jupyter_ai_persona_manager.persona_manager import find_persona_files, load_from_dir
+from traitlets.config import LoggingConfigurable
+
+from jupyter_ai_persona_manager.base_persona import BasePersona, PersonaDefaults
+from jupyter_ai_persona_manager.persona_manager import (
+    PersonaManager,
+    find_persona_files,
+    load_from_dir,
+)
 
 
 @pytest.fixture
@@ -118,3 +125,57 @@ class TestPersona(BasePersona):
         assert result[0]["persona_class"] is None
         assert result[0]["traceback"] is not None
         assert "ZeroDivisionError" in result[0]["traceback"]
+
+
+class TestInitPersonasKwargs:
+    """Test that _init_personas passes extra kwargs to persona constructors."""
+
+    def test_kwargs_passed_to_persona_constructor(self, mock_ychat):
+        """Verify that 'kwargs' from persona class entries are forwarded."""
+
+        received_kwargs = {}
+
+        class StubPersona(BasePersona):
+            def __init__(self, *args, extra_arg=None, **kwargs):
+                received_kwargs["extra_arg"] = extra_arg
+                super().__init__(*args, **kwargs)
+
+            @property
+            def defaults(self):
+                return PersonaDefaults(
+                    name="Stub",
+                    description="stub",
+                    avatar_path="/stub.svg",
+                    system_prompt="stub",
+                )
+
+            async def process_message(self, message):
+                pass
+
+        manager = LoggingConfigurable.__new__(PersonaManager)
+        LoggingConfigurable.__init__(manager)
+        manager.ychat = mock_ychat
+        manager.log = Mock()
+        manager._local_persona_classes = None
+
+        # Inject persona classes directly, bypassing entry point loading
+        PersonaManager._ep_persona_classes = [
+            {
+                "module": "test",
+                "persona_class": StubPersona,
+                "traceback": None,
+                "kwargs": {"extra_arg": "hello"},
+            }
+        ]
+
+        try:
+            # Patch asyncio.create_task to avoid "no running event loop"
+            # from PersonaAwareness heartbeat initialization
+            with patch(
+                "jupyter_ai_persona_manager.persona_awareness.asyncio.create_task"
+            ):
+                personas = manager._init_personas()
+            assert received_kwargs["extra_arg"] == "hello"
+            assert len(personas) == 1
+        finally:
+            PersonaManager._ep_persona_classes = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "importlib_metadata>=4.0.0",
     "jupyter_ai_router>=0.0.1",
+    "pyyaml>=6.0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
This is a PR that _definitely_ will need some work to clean up but shows off the general idea of how we could build personas off of markdown files with YAML front matter.

A few specific points for cleanup: 

1) There are just placeholders for parsing tools and mcp servers. The custom parser does pick up those keys but it does nothing with them.

2) The parsing logic is custom... sorta... and we did discuss the idea of enhancing these features and adding additional functionality using MyST.

3) The persona manager already hardcodes the default persona as jupyternaut but there is no requirement for jupyternaut to be installed + there isn't really a clean way in the UI to select a default persona. I think it would be a good addition to have a way to select a default persona in Jupyter settings.

### Some Visual Assets 


![md-pr-gif](https://github.com/user-attachments/assets/7172143c-a059-4fba-afb8-75e5d45e1201)



