### PR TITLE
Rescan entry point personas on refresh

### DIFF
--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -490,9 +490,9 @@ class PersonaManager(LoggingConfigurable):
 
     async def refresh_personas(self):
         """
-        Method that reloads all persona classes defined locally under
-        `.jupyter/personas`, and re-initializes each persona class available in
-        the current chat.
+        Method that reloads all persona classes defined by entry points and
+        locally under `.jupyter/personas`, and re-initializes each persona class
+        available in the current chat.
 
         This method is public because it is called by `jupyter_ai_chat_commands`
         when the `/refresh-personas` slash command is sent.
@@ -500,7 +500,8 @@ class PersonaManager(LoggingConfigurable):
         # Shutdown all personas
         await self.shutdown_personas()
 
-        # Refresh local personas and re-initialize persona instances
+        # Refresh entry-point and local personas, then re-initialize persona instances
+        self._init_ep_persona_classes()
         self._init_local_persona_classes()
         self._personas = self._init_personas()
 

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -477,9 +477,9 @@ class PersonaManager(LoggingConfigurable):
 
     async def refresh_personas(self):
         """
-        Method that reloads all persona classes defined locally under
-        `.jupyter/personas`, and re-initializes each persona class available in
-        the current chat.
+        Method that reloads all persona classes defined by entry points and
+        locally under `.jupyter/personas`, and re-initializes each persona class
+        available in the current chat.
 
         This method is public because it is called by `jupyter_ai_chat_commands`
         when the `/refresh-personas` slash command is sent.
@@ -487,7 +487,8 @@ class PersonaManager(LoggingConfigurable):
         # Shutdown all personas
         await self.shutdown_personas()
 
-        # Refresh local personas and re-initialize persona instances
+        # Refresh entry-point and local personas, then re-initialize persona instances
+        self._init_ep_persona_classes()
         self._init_local_persona_classes()
         self._personas = self._init_personas()
 

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -8,8 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from jupyterlab_chat.models import Message
-from jupyter_ai_persona_manager.base_persona import BasePersona
+from jupyter_ai_persona_manager.base_persona import BasePersona, PersonaDefaults
 from jupyter_ai_persona_manager.persona_manager import (
+    PersonaManager,
+    PersonaRequirementsUnmet,
     _safe_process,
     find_persona_files,
     load_from_dir,
@@ -123,6 +125,82 @@ class TestPersona(BasePersona):
         assert result[0]["persona_class"] is None
         assert result[0]["traceback"] is not None
         assert "ZeroDivisionError" in result[0]["traceback"]
+
+
+class RefreshedEntryPointPersona(BasePersona):
+    def __init__(self, *args, ychat, **kwargs):
+        self.ychat = ychat
+
+    @property
+    def defaults(self):
+        return PersonaDefaults(
+            name="Refreshed Entry Point Persona",
+            description="A persona that becomes available after refresh",
+            avatar_path="/test/avatar.svg",
+            system_prompt="Test system prompt"
+        )
+
+    async def process_message(self, message: Message):
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+class TestRefreshPersonas:
+    @pytest.mark.asyncio
+    async def test_refresh_personas_rescans_entry_points(
+        self, monkeypatch, tmp_dir
+    ):
+        load_results = [
+            PersonaRequirementsUnmet("missing CLI"),
+            RefreshedEntryPointPersona
+        ]
+
+        class MockEntryPoint:
+            name = "refreshed-persona"
+            value = "test_persona_manager:RefreshedEntryPointPersona"
+
+            def load(self):
+                result = load_results.pop(0)
+                if isinstance(result, Exception):
+                    raise result
+                return result
+
+        class MockEntryPoints:
+            def select(self, group):
+                return [MockEntryPoint()]
+
+        monkeypatch.setattr(PersonaManager, "_ep_persona_classes", None)
+        monkeypatch.setattr(
+            "jupyter_ai_persona_manager.persona_manager.entry_points",
+            lambda: MockEntryPoints()
+        )
+
+        mock_ychat = Mock()
+        mock_ychat.get_id.return_value = "test-chat-id"
+        mock_ychat._background_tasks = set()
+
+        mock_fileid_manager = Mock()
+        mock_fileid_manager.get_path.return_value = "chat.ipynb"
+
+        manager = PersonaManager(
+            room_id="room:chat:file-id",
+            ychat=mock_ychat,
+            fileid_manager=mock_fileid_manager,
+            root_dir=str(tmp_dir),
+            event_loop=Mock(),
+            default_persona_id=""
+        )
+        manager.send_system_message = Mock()
+
+        assert manager.personas == {}
+
+        await manager.refresh_personas()
+
+        assert len(manager.personas) == 1
+        refreshed_persona = next(iter(manager.personas.values()))
+        assert refreshed_persona.name == "Refreshed Entry Point Persona"
 
 
 # ---------------------------------------------------------------------------

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -9,10 +9,11 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from jupyterlab_chat.models import Message
-from jupyter_ai_persona_manager.base_persona import BasePersona
+from jupyter_ai_persona_manager.base_persona import BasePersona, PersonaDefaults
 from jupyter_ai_persona_manager.persona_manager import (
     SYSTEM_USERNAME,
     PersonaManager,
+    PersonaRequirementsUnmet,
     _safe_process,
     find_persona_files,
     format_persona_load_errors,
@@ -128,6 +129,106 @@ class TestPersona(BasePersona):
         assert result[0]["persona_class"] is None
         assert result[0]["traceback"] is not None
         assert "ZeroDivisionError" in result[0]["traceback"]
+
+
+class RefreshedEntryPointPersona(BasePersona):
+    """Minimal persona used only by the refresh entry-point regression test."""
+
+    @property
+    def defaults(self):
+        return PersonaDefaults(
+            name="Refreshed Entry Point Persona",
+            description="A persona that becomes available after refresh",
+            avatar_path="/test/avatar.svg",
+            system_prompt="Test system prompt",
+        )
+
+    async def process_message(self, message: Message):
+        pass
+
+    async def shutdown(self) -> None:
+        # Avoid BasePersona.shutdown()'s awareness cleanup in this unit test.
+        pass
+
+
+class TestRefreshPersonas:
+    @pytest.mark.asyncio
+    async def test_refresh_personas_rescans_entry_points(
+        self, monkeypatch, tmp_dir, mock_ychat, mock_fileid_manager
+    ):
+        """
+        /refresh-personas must re-scan entry points, not just local files.
+
+        The entry point is unavailable at startup (requirements unmet) and only
+        becomes loadable on the second scan during refresh.
+        """
+        from pycrdt import Awareness, Doc
+
+        load_results = [
+            PersonaRequirementsUnmet("missing CLI"),
+            RefreshedEntryPointPersona,
+        ]
+
+        class MockEntryPoint:
+            name = "refreshed-persona"
+            value = "test_persona_manager:RefreshedEntryPointPersona"
+
+            def load(self):
+                result = load_results.pop(0)
+                if isinstance(result, Exception):
+                    raise result
+                return result
+
+        class MockEntryPoints:
+            def select(self, group):
+                return [MockEntryPoint()]
+
+        # Ensure a clean class-level cache and mock entry points for both the
+        # initial PersonaManager construction and the later refresh scan.
+        monkeypatch.setattr(PersonaManager, "_ep_persona_classes", None)
+        monkeypatch.setattr(
+            "jupyter_ai_persona_manager.persona_manager.entry_points",
+            lambda: MockEntryPoints(),
+        )
+
+        # Keep local persona discovery out of this test; focus on entry points.
+        mock_fileid_manager.get_path.return_value = "chat.ipynb"
+
+        # PersonaManager / BasePersona now publish awareness state. Use a real
+        # pycrdt Awareness so construction and refresh don't trip over Mocks.
+        ydoc = Doc()
+        mock_ychat._ydoc = ydoc
+        mock_ychat.awareness = Awareness(ydoc=ydoc)
+        mock_ychat._yusers = {}
+
+        manager = PersonaManager(
+            room_id="room:chat:file-id",
+            ychat=mock_ychat,
+            fileid_manager=mock_fileid_manager,
+            root_dir=str(tmp_dir),
+            event_loop=Mock(),
+        )
+        manager.send_system_message = Mock()
+        # parent stays None; refresh_personas' avatar-cache rebuild is best-effort
+        # and swallows the resulting AttributeError.
+
+        # Cancel awareness heartbeats started under the running test event loop.
+        if getattr(manager._awareness, "_heartbeat_task", None):
+            manager._awareness._heartbeat_task.cancel()
+
+        assert manager.personas == {}
+
+        await manager.refresh_personas()
+
+        # Newly created persona awareness may also start a heartbeat; cancel it.
+        for persona in manager.personas.values():
+            task = getattr(getattr(persona, "awareness", None), "_heartbeat_task", None)
+            if task is not None:
+                task.cancel()
+
+        assert len(manager.personas) == 1
+        refreshed_persona = next(iter(manager.personas.values()))
+        assert refreshed_persona.name == "Refreshed Entry Point Persona"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Update `/refresh-personas` so it re-scans personas provided through Python entry points, not only local `.jupyter/personas` files.
- Add a regression test covering an entry point persona that is unavailable at startup but becomes available after refresh.

Closes #42

## Verification

- `pytest -q jupyter_ai_persona_manager/tests/test_persona_manager.py`
- `pytest -q`