### PR TITLE
Route messages to a selectable active persona

### DIFF
--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -437,8 +437,19 @@ class PersonaManager(LoggingConfigurable):
         if self.ACTIVE_PERSONA_METADATA_KEY in metadata:
             stored_id = metadata[self.ACTIVE_PERSONA_METADATA_KEY]
             if not stored_id:
+                # Empty string is an explicit "no one replies" selection.
                 return None
-            return self.personas.get(stored_id)
+            persona = self.personas.get(stored_id)
+            if persona is not None:
+                return persona
+            # The stored persona was uninstalled or renamed. Fall back to the
+            # default rather than silently disabling all replies.
+            self.log.warning(
+                "Stored active persona '%s' not found in chat '%s'; "
+                "falling back to the default persona.",
+                stored_id,
+                self.room_id,
+            )
         if self.default_persona:
             return self.default_persona
         if len(self.personas) == 1:
@@ -548,6 +559,10 @@ class PersonaManager(LoggingConfigurable):
         # Refresh local personas and re-initialize persona instances
         self._init_local_persona_classes()
         self._personas = self._init_personas()
+
+        # Re-resolve the active persona against the fresh instances, since the
+        # previous instance was just shut down. The id is persisted in metadata.
+        self.active_persona = self._init_active_persona()
 
         # Rebuild avatar cache after reloading personas
         # Get all persona managers from parent (extension) settings

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -484,35 +484,35 @@ class PersonaManager(LoggingConfigurable):
         Method that routes an incoming message to the correct personas by
         calling their `process_message()` methods.
 
-        - If the chat has multiple users, then each persona only replies
-          when `@`-mentioned.
+        - Messages from a persona or the system only go to explicitly mentioned
+          personas, to avoid persona-to-persona reply loops.
 
-        - If there is only one user, the active persona replies. An `@`-mention
-          is an override that also updates the active persona (when
-          `mention_updates_active`). Selecting no one (`active_persona is None`)
-          means no one replies. The active persona defaults to
-          `PersonaManager.default_persona`.
+        - A message from a human goes to the active persona, in single- and
+          multi-human chats alike. An `@`-mention overrides this, replying to
+          the mentioned personas and (when `mention_updates_active`) updating
+          the active persona. Selecting no one (`active_persona is None`) means
+          no one replies, which is how a user opts out of AI replies in a shared
+          chat. The active persona defaults to `PersonaManager.default_persona`.
         """
 
         # Gather routing context
-        human_users = self.get_active_human_users()
         sender_not_human = (
             is_persona(message.sender) or message.sender == SYSTEM_USERNAME
         )
         mentioned_personas = self.get_mentioned_personas(message)
-        human_user_count = len(human_users)
 
-        # Multi-user case & non-human message case: only route message to
-        # mentioned personas, so the AI does not interject in a conversation
-        # between humans.
-        if sender_not_human or human_user_count > 1:
+        # Messages from a persona or the system only go to mentioned personas,
+        # to avoid persona-to-persona reply loops.
+        if sender_not_human:
             if mentioned_personas:
                 self._broadcast(message, to_personas=mentioned_personas)
             return
 
-        # Single-human case: route to the active persona. An `@`-mention is an
-        # override that replies to the mentioned personas and (when
-        # `mention_updates_active`) updates the active persona.
+        # Human sender: route to the active persona. An `@`-mention overrides
+        # this, replying to the mentioned personas and (when
+        # `mention_updates_active`) updating the active persona. This is the same
+        # in single- and multi-human chats; the selector (including "no one") is
+        # the explicit control over who replies.
         if mentioned_personas and self.mention_updates_active:
             self.set_active_persona(mentioned_personas[0])
             targeted_personas = mentioned_personas
@@ -520,7 +520,7 @@ class PersonaManager(LoggingConfigurable):
             targeted_personas = [self.active_persona] if self.active_persona else []
 
         self.log.info(
-            "Routing message (single human): active=%s, mentioned=%s -> %s",
+            "Routing message: active=%s, mentioned=%s -> %s",
             self.active_persona.name if self.active_persona else None,
             [p.name for p in mentioned_personas],
             [p.name for p in targeted_personas],

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from importlib_metadata import entry_points
 from jupyterlab_chat.models import Message, NewMessage, User
-from traitlets import List, Unicode, default
+from traitlets import Bool, List, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 from .base_persona import BasePersona
@@ -87,6 +87,17 @@ class PersonaManager(LoggingConfigurable):
         config=True,
     )
 
+    mention_updates_active = Bool(
+        default_value=True,
+        help=""
+        "When True, an `@`-mention also sets the active persona that replies to "
+        "subsequent unmentioned messages (the multi-participant model). When "
+        "False, `@`-mentions are ignored for routing and only the active-persona "
+        "selector chooses who replies (the single-active-persona model). "
+        "Defaults to: True. ",
+        config=True,
+    )
+
     builtin_mcp_servers = List(
         allow_none=True,
         help=(
@@ -128,7 +139,13 @@ class PersonaManager(LoggingConfigurable):
     root_dir: str
     event_loop: "AbstractEventLoop"
     base_url: str
-    last_mentioned_persona: BasePersona | None
+    active_persona: BasePersona | None
+    """
+    The persona that replies to unmentioned messages in a single-human chat. Set
+    by the active-persona selector or by an `@`-mention (when
+    `mention_updates_active` is True). `None` means no one replies. Initialized
+    from chat metadata, falling back to the default persona.
+    """
 
     log: Logger  # type: ignore
     """
@@ -167,13 +184,14 @@ class PersonaManager(LoggingConfigurable):
         # Store file ID
         self.file_id = room_id.split(":")[2]
 
-        # Initialize last_mentioned_persona to None
-        self.last_mentioned_persona = None
-
         self._init_persona_classes()
         self.log.info(f"Persona classes loaded in chat '{self.room_id}'.")
         self._personas = self._init_personas()
         self.log.info(f"Personas initialized in chat '{self.room_id}'.")
+
+        # Initialize the active persona from chat metadata, falling back to the
+        # default persona (or the sole persona if there is exactly one).
+        self.active_persona = self._init_active_persona()
         if self.default_persona:
             self.log.info(
                 f"Default persona set to '{self.default_persona.name}' in chat '{self.room_id}'."
@@ -407,6 +425,37 @@ class PersonaManager(LoggingConfigurable):
             return None
         return self.personas.get(self.default_persona_id)
 
+    ACTIVE_PERSONA_METADATA_KEY = "active_persona_id"
+
+    def _init_active_persona(self) -> BasePersona | None:
+        """
+        Resolve the active persona at startup: from chat metadata if it was set
+        before, otherwise the default persona, otherwise the sole persona if the
+        chat has exactly one. An empty stored value means "no one replies".
+        """
+        metadata = self.ychat.get_metadata() or {}
+        if self.ACTIVE_PERSONA_METADATA_KEY in metadata:
+            stored_id = metadata[self.ACTIVE_PERSONA_METADATA_KEY]
+            if not stored_id:
+                return None
+            return self.personas.get(stored_id)
+        if self.default_persona:
+            return self.default_persona
+        if len(self.personas) == 1:
+            return next(iter(self.personas.values()))
+        return None
+
+    def set_active_persona(self, persona: BasePersona | None) -> None:
+        """
+        Set the persona that replies to unmentioned messages, and persist the
+        choice with the chat so it survives a reload. `None` means no one
+        replies.
+        """
+        self.active_persona = persona
+        self.ychat.set_metadata(
+            self.ACTIVE_PERSONA_METADATA_KEY, persona.id if persona else ""
+        )
+
     def get_mentioned_personas(self, new_message: Message) -> list[BasePersona]:
         """
         Returns a list of all personas `@`-mentioned in a chat message, given a
@@ -427,12 +476,11 @@ class PersonaManager(LoggingConfigurable):
         - If the chat has multiple users, then each persona only replies
           when `@`-mentioned.
 
-        - If there is only one user, the last mentioned persona replies
-          unless another persona is `@`-mentioned. The last mentioned persona
-          defaults to `PersonaManager.default_persona` after starting the server.
-
-        - If only one persona exists as well, then the persona always replies,
-          regardless of whether it is `@`-mentioned.
+        - If there is only one user, the active persona replies. An `@`-mention
+          is an override that also updates the active persona (when
+          `mention_updates_active`). Selecting no one (`active_persona is None`)
+          means no one replies. The active persona defaults to
+          `PersonaManager.default_persona`.
         """
 
         # Gather routing context
@@ -440,36 +488,33 @@ class PersonaManager(LoggingConfigurable):
         sender_not_human = (
             is_persona(message.sender) or message.sender == SYSTEM_USERNAME
         )
-        sender_is_human = not sender_not_human
         mentioned_personas = self.get_mentioned_personas(message)
         human_user_count = len(human_users)
-        persona_count = len(self.personas)
 
         # Multi-user case & non-human message case: only route message to
-        # mentioned personas
+        # mentioned personas, so the AI does not interject in a conversation
+        # between humans.
         if sender_not_human or human_user_count > 1:
             if mentioned_personas:
                 self._broadcast(message, to_personas=mentioned_personas)
             return
 
-        # Single user + multiple personas case: route message to mentioned
-        # personas if present. Otherwise route message to last mentioned
-        # persona, falling back to the default set by the
-        # `PersonaManager.default_persona_id` configurable trait.
-        if persona_count > 1:
-            # Update last mentioned persona
-            if mentioned_personas and sender_is_human:
-                self.last_mentioned_persona = mentioned_personas[0]
-
-            default_persona = self.last_mentioned_persona or self.default_persona
+        # Single-human case: route to the active persona. An `@`-mention is an
+        # override that replies to the mentioned personas and (when
+        # `mention_updates_active`) updates the active persona.
+        if mentioned_personas and self.mention_updates_active:
+            self.set_active_persona(mentioned_personas[0])
             targeted_personas = mentioned_personas
-            if default_persona and not targeted_personas:
-                targeted_personas = [default_persona]
-            self._broadcast(message, to_personas=targeted_personas)
-            return
+        else:
+            targeted_personas = [self.active_persona] if self.active_persona else []
 
-        # Default case (single user, 0/1 personas): persona always replies if present
-        self._broadcast(message, to_personas=self.personas)
+        self.log.info(
+            "Routing message (single human): active=%s, mentioned=%s -> %s",
+            self.active_persona.name if self.active_persona else None,
+            [p.name for p in mentioned_personas],
+            [p.name for p in targeted_personas],
+        )
+        self._broadcast(message, to_personas=targeted_personas)
         return
     
     def _broadcast(

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -495,31 +495,23 @@ class PersonaManager(LoggingConfigurable):
           chat. The active persona defaults to `PersonaManager.default_persona`.
         """
 
-        # Gather routing context
         sender_not_human = (
             is_persona(message.sender) or message.sender == SYSTEM_USERNAME
         )
         mentioned_personas = self.get_mentioned_personas(message)
 
-        # Messages from a persona or the system only go to mentioned personas,
-        # to avoid persona-to-persona reply loops.
         if sender_not_human:
             if mentioned_personas:
                 self._broadcast(message, to_personas=mentioned_personas)
             return
 
-        # Human sender: route to the active persona. An `@`-mention overrides
-        # this, replying to the mentioned personas and (when
-        # `mention_updates_active`) updating the active persona. This is the same
-        # in single- and multi-human chats; the selector (including "no one") is
-        # the explicit control over who replies.
         if mentioned_personas and self.mention_updates_active:
             self.set_active_persona(mentioned_personas[0])
             targeted_personas = mentioned_personas
         else:
             targeted_personas = [self.active_persona] if self.active_persona else []
 
-        self.log.info(
+        self.log.debug(
             "Routing message: active=%s, mentioned=%s -> %s",
             self.active_persona.name if self.active_persona else None,
             [p.name for p in mentioned_personas],

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -679,15 +679,6 @@ class PersonaManager(LoggingConfigurable):
         )
         return McpSettings(mcp_servers=all_servers)
 
-    def get_active_human_users(self):
-        """Returns active human users in a chat session"""
-        users = []
-        for value in [k for k in self.ychat.awareness.states.values()]:
-            if "user" in value.keys() and not is_persona(value["user"]["username"]):
-                users.append(value["user"])
-
-        return users
-
     async def shutdown_personas(self):
         """
         Shuts down each persona. See `BasePersona.shutdown()` for more info.

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -10,6 +10,8 @@ import pytest
 from jupyterlab_chat.models import Message
 from jupyter_ai_persona_manager.base_persona import BasePersona
 from jupyter_ai_persona_manager.persona_manager import (
+    SYSTEM_USERNAME,
+    PersonaManager,
     _safe_process,
     find_persona_files,
     load_from_dir,
@@ -203,3 +205,97 @@ class TestSafeProcess:
         await _safe_process(persona, message)
 
         persona.handle_uncaught_exception.assert_not_called()
+
+
+PERSONA_SENDER = "jupyter-ai-personas::pkg::Bot"
+HUMAN_SENDER = "human-1"
+
+
+def _routing_manager(active_persona=None, mention_updates_active=True):
+    """A PersonaManager with only the state on_chat_message routing reads.
+
+    Uses ``__new__`` to get the traitlets machinery without the heavy ``__init__``
+    (which loads personas), then sets just the attributes routing touches.
+    """
+    pm = PersonaManager.__new__(PersonaManager)
+    pm.mention_updates_active = mention_updates_active
+    pm.active_persona = active_persona
+    pm.ychat = Mock()
+    pm.get_mentioned_personas = Mock(return_value=[])
+    pm._broadcast = Mock()
+    return pm
+
+
+def _message(sender):
+    message = Mock(spec=Message)
+    message.sender = sender
+    return message
+
+
+def _replied_to(pm):
+    """The personas on_chat_message decided should reply."""
+    return pm._broadcast.call_args.kwargs["to_personas"]
+
+
+class TestOnChatMessageRouting:
+    """Who replies to a message. Asserts on the routing decision (the persona
+    list handed to delivery), not on how delivery happens."""
+
+    def test_human_message_goes_to_the_active_persona(self):
+        active = _make_mock_persona()
+        pm = _routing_manager(active_persona=active)
+
+        pm.on_chat_message("room", _message(HUMAN_SENDER))
+
+        assert _replied_to(pm) == [active]
+
+    def test_mention_replies_to_the_mentioned_persona_and_makes_it_active(self):
+        mentioned = _make_mock_persona()
+        pm = _routing_manager(active_persona=None, mention_updates_active=True)
+        pm.get_mentioned_personas = Mock(return_value=[mentioned])
+
+        pm.on_chat_message("room", _message(HUMAN_SENDER))
+
+        assert _replied_to(pm) == [mentioned]
+        assert pm.active_persona is mentioned
+
+    def test_mention_does_not_change_active_when_flag_is_off(self):
+        active = _make_mock_persona()
+        mentioned = _make_mock_persona()
+        pm = _routing_manager(active_persona=active, mention_updates_active=False)
+        pm.get_mentioned_personas = Mock(return_value=[mentioned])
+
+        pm.on_chat_message("room", _message(HUMAN_SENDER))
+
+        assert pm.active_persona is active
+
+    def test_no_active_persona_means_no_one_replies(self):
+        pm = _routing_manager(active_persona=None)
+
+        pm.on_chat_message("room", _message(HUMAN_SENDER))
+
+        assert _replied_to(pm) == []
+
+    def test_persona_sender_without_mention_is_ignored(self):
+        pm = _routing_manager(active_persona=_make_mock_persona())
+
+        pm.on_chat_message("room", _message(PERSONA_SENDER))
+
+        pm._broadcast.assert_not_called()
+
+    def test_persona_sender_with_mention_replies_to_the_mentioned_persona(self):
+        active = _make_mock_persona()
+        mentioned = _make_mock_persona()
+        pm = _routing_manager(active_persona=active)
+        pm.get_mentioned_personas = Mock(return_value=[mentioned])
+
+        pm.on_chat_message("room", _message(PERSONA_SENDER))
+
+        assert _replied_to(pm) == [mentioned]
+
+    def test_system_sender_without_mention_is_ignored(self):
+        pm = _routing_manager(active_persona=_make_mock_persona())
+
+        pm.on_chat_message("room", _message(SYSTEM_USERNAME))
+
+        pm._broadcast.assert_not_called()

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -259,7 +259,7 @@ class TestOnChatMessageRouting:
         assert _replied_to(pm) == [mentioned]
         assert pm.active_persona is mentioned
 
-    def test_mention_does_not_change_active_when_flag_is_off(self):
+    def test_mention_is_ignored_for_routing_when_flag_is_off(self):
         active = _make_mock_persona()
         mentioned = _make_mock_persona()
         pm = _routing_manager(active_persona=active, mention_updates_active=False)
@@ -267,6 +267,7 @@ class TestOnChatMessageRouting:
 
         pm.on_chat_message("room", _message(HUMAN_SENDER))
 
+        assert _replied_to(pm) == [active]
         assert pm.active_persona is active
 
     def test_no_active_persona_means_no_one_replies(self):
@@ -299,3 +300,59 @@ class TestOnChatMessageRouting:
         pm.on_chat_message("room", _message(SYSTEM_USERNAME))
 
         pm._broadcast.assert_not_called()
+
+
+class TestActivePersonaResolution:
+    """How the active persona is resolved at startup (_init_active_persona)."""
+
+    def _manager(self, *, metadata, personas, default_id=""):
+        pm = PersonaManager.__new__(PersonaManager)
+        pm.default_persona_id = default_id
+        pm.room_id = "room"
+        pm._personas = personas
+        pm.ychat = Mock()
+        pm.ychat.get_metadata.return_value = metadata
+        return pm
+
+    def test_uses_the_stored_active_persona_when_it_still_exists(self):
+        stored = _make_mock_persona()
+        pm = self._manager(metadata={"active_persona_id": "p1"}, personas={"p1": stored})
+
+        assert pm._init_active_persona() is stored
+
+    def test_empty_stored_value_means_no_one(self):
+        pm = self._manager(
+            metadata={"active_persona_id": ""}, personas={"p1": _make_mock_persona()}
+        )
+
+        assert pm._init_active_persona() is None
+
+    def test_falls_back_to_default_when_the_stored_persona_is_gone(self):
+        default = _make_mock_persona()
+        pm = self._manager(
+            metadata={"active_persona_id": "gone"},
+            personas={"d": default},
+            default_id="d",
+        )
+
+        assert pm._init_active_persona() is default
+
+    def test_uses_the_default_persona_when_nothing_is_stored(self):
+        default = _make_mock_persona()
+        pm = self._manager(metadata={}, personas={"d": default}, default_id="d")
+
+        assert pm._init_active_persona() is default
+
+    def test_uses_the_sole_persona_when_no_default_and_only_one(self):
+        only = _make_mock_persona()
+        pm = self._manager(metadata={}, personas={"only": only})
+
+        assert pm._init_active_persona() is only
+
+    def test_no_one_when_no_default_and_several_personas(self):
+        pm = self._manager(
+            metadata={},
+            personas={"a": _make_mock_persona(), "b": _make_mock_persona()},
+        )
+
+        assert pm._init_active_persona() is None


### PR DESCRIPTION
Fixes #38. Fixes #48.

## Problem

Who replies to an unmentioned message is decided by a human-count heuristic: once more than one human is in a chat, personas stay silent unless explicitly `@`-mentioned. The count comes from `get_active_human_users()`, which counts awareness slots rather than unique humans, so a browser refresh (which adds awareness clients) can silently push the count past one and make personas stop responding (#38, #48). It is also surprising in normal use: a teammate joining a chat changes whether the AI replies.

## Proposed solution

Replace the heuristic with an explicit active persona: the one persona that replies to unmentioned human messages, the same in single- and multi-human chats.

- `PersonaManager` gains an `active_persona` field and a `mention_updates_active` trait (default on). In `on_chat_message`: a human message goes to the active persona; an `@`-mention overrides it and (when `mention_updates_active`) makes the mentioned persona active; `active_persona is None` ("no one") means no AI reply, the explicit opt-out. Messages from a persona or the system go only to explicitly mentioned personas, to avoid reply loops.
- `_init_active_persona()` resolves the active persona at startup from chat metadata (`active_persona_id`), falling back to the default persona, then the sole persona if the chat has exactly one. `set_active_persona()` persists the choice in chat metadata so it survives reloads.
- Removes the now-dead `get_active_human_users()` and the human-count gate.

The frontend selector that drives this, and the per-persona model/mode controls, lives in the companion PR jupyter-ai-acp-client#129.

## Testing

`pytest` green (58 passing). New tests cover the routing decision (`TestOnChatMessageRouting`: active persona replies, mention overrides and updates active, "no one" suppresses replies, persona/system senders gated) and startup resolution (`TestActivePersonaResolution`: stored id, missing-id fallback to default, empty means no one, sole persona).

Manual repro of the #38/#48 silent drop, before vs after:

1. Open a chat with a default persona. Send a message without an `@`-mention.
   - Before and after: the persona replies.
2. Refresh the browser, or open the same chat in a second tab (a second awareness client). Send another message.
   - Before: no reply, the message is silently dropped (awareness now reports two "humans").
   - After: the persona replies.
3. Select "No one" and send a message.
   - After: no AI reply (the explicit opt-out).

Also verified live across multiple agents and a two-human chat: the active persona replies without an `@`, the selector changes who replies, and a second client joining no longer silences the persona.

## Other considerations

The active persona is per-chat: in a shared chat everyone drives the same selection and the active persona replies to all unmentioned messages, with "No one" as the opt-out. A per-person active persona is a possible follow-up.
