### PR TITLE
Update routing to be metadata-based, not mention-based

### DIFF
--- a/jupyter_ai_persona_manager/extension.py
+++ b/jupyter_ai_persona_manager/extension.py
@@ -67,6 +67,13 @@ class PersonaManagerExtension(ExtensionApp):
         if 'persona-managers' not in self.settings['jupyter-ai']:
             self.settings['jupyter-ai']['persona-managers'] = {}
 
+        # Advertise the default persona ID to the frontend via PageConfig, so a
+        # chat with no prior persona selection can pre-select it without a
+        # network round-trip. Read on the frontend via
+        # `PageConfig.getOption('jupyter_ai_default_persona')`.
+        page_config = self.serverapp.web_app.settings.setdefault("page_config_data", {})
+        page_config["jupyter_ai_default_persona"] = self._default_persona_id()
+
         # Set up router integration task
         self.event_loop.create_task(self._setup_router_integration())
 
@@ -83,6 +90,19 @@ class PersonaManagerExtension(ExtensionApp):
         self.log.info(f"Registered {self.name} server extension")
         startup_time = round((time.time() - start) * 1000)
         self.log.info(f"Initialized Persona Manager server extension in {startup_time} ms.")
+
+    def _default_persona_id(self) -> str:
+        """
+        The configured default persona ID, resolving any user override of
+        `PersonaManager.default_persona_id` before any `PersonaManager` is
+        instantiated. Returns "" when the default is disabled (`allow_none`).
+        """
+        PersonaManagerClass = self.persona_manager_class
+        class_config = self.config.get(PersonaManagerClass.__name__, {})
+        if "default_persona_id" in class_config:
+            # An explicit `None` override disables the default persona.
+            return class_config["default_persona_id"] or ""
+        return PersonaManagerClass.default_persona_id.default_value or ""
 
     async def _setup_router_integration(self) -> None:
         """

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -128,12 +128,6 @@ class PersonaManager(LoggingConfigurable):
     root_dir: str
     event_loop: "AbstractEventLoop"
     base_url: str
-    active_persona: BasePersona | None
-    """
-    The fallback persona that replies to messages whose metadata names no target
-    persona. Set by the active-persona selector. `None` means no one replies.
-    Initialized from chat metadata, falling back to the default persona.
-    """
 
     log: Logger  # type: ignore
     """
@@ -177,9 +171,6 @@ class PersonaManager(LoggingConfigurable):
         self._personas = self._init_personas()
         self.log.info(f"Personas initialized in chat '{self.room_id}'.")
 
-        # Initialize the active persona from chat metadata, falling back to the
-        # default persona (or the sole persona if there is exactly one).
-        self.active_persona = self._init_active_persona()
         if self.default_persona:
             self.log.info(
                 f"Default persona set to '{self.default_persona.name}' in chat '{self.room_id}'."
@@ -413,113 +404,36 @@ class PersonaManager(LoggingConfigurable):
             return None
         return self.personas.get(self.default_persona_id)
 
-    ACTIVE_PERSONA_METADATA_KEY = "active_persona_id"
-
-    def _init_active_persona(self) -> BasePersona | None:
-        """
-        Resolve the active persona at startup: from chat metadata if it was set
-        before, otherwise the default persona, otherwise the sole persona if the
-        chat has exactly one. An empty stored value means "no one replies".
-        """
-        metadata = self.ychat.get_metadata() or {}
-        if self.ACTIVE_PERSONA_METADATA_KEY in metadata:
-            stored_id = metadata[self.ACTIVE_PERSONA_METADATA_KEY]
-            if not stored_id:
-                # Empty string is an explicit "no one replies" selection.
-                return None
-            persona = self.personas.get(stored_id)
-            if persona is not None:
-                return persona
-            # The stored persona was uninstalled or renamed. Fall back to the
-            # default rather than silently disabling all replies.
-            self.log.warning(
-                "Stored active persona '%s' not found in chat '%s'; "
-                "falling back to the default persona.",
-                stored_id,
-                self.room_id,
-            )
-        if self.default_persona:
-            return self.default_persona
-        if len(self.personas) == 1:
-            return next(iter(self.personas.values()))
-        return None
-
-    def set_active_persona(self, persona: BasePersona | None) -> None:
-        """
-        Set the persona that replies to unmentioned messages, and persist the
-        choice with the chat so it survives a reload. `None` means no one
-        replies.
-        """
-        self.active_persona = persona
-        self.ychat.set_metadata(
-            self.ACTIVE_PERSONA_METADATA_KEY, persona.id if persona else ""
-        )
-
-    PERSONA_METADATA_KEY = "persona"
+    TO_PERSONA_METADATA_KEY = "to_persona"
     """
-    Key in a message's `metadata` dict holding the ID of the persona that should
-    reply to it. Stamped onto outgoing messages by the chat input's persona
-    picker.
+    Key in a message's `metadata` dict holding the ID of the persona the message
+    is directed to. The chat input's persona picker stamps this onto each
+    outgoing message.
     """
-
-    def get_target_persona(self, message: Message) -> BasePersona | None:
-        """
-        Returns the persona a message is addressed to, read from its metadata.
-
-        The chat input stamps `metadata["persona"]` with the ID of the selected
-        persona. Returns `None` if the message carries no persona (e.g. an older
-        message or an external client), or if the named persona is not installed
-        in this chat; callers fall back to the active persona in that case.
-        """
-        metadata = message.metadata or {}
-        persona_id = metadata.get(self.PERSONA_METADATA_KEY)
-        if not persona_id:
-            return None
-        return self.personas.get(persona_id)
 
     def on_chat_message(self, room_id: str, message: Message):
         """
-        Routes an incoming message to a single persona by calling its
-        `process_message()` method.
+        Routes an incoming message to the persona it is addressed to.
 
-        The target is read from the message's own metadata
-        (`metadata["persona"]`), which the chat input's persona picker stamps
-        onto each outgoing message. When a message carries no persona — an older
-        message, or one from a client that doesn't set it — we fall back to the
-        chat's active persona (which defaults to `PersonaManager.default_persona`
-        and is `None` when the user has opted out of AI replies).
+        The target persona's ID is read from the message's own metadata
+        (`metadata["to_persona"]`), which the chat input's persona picker stamps
+        onto each outgoing message. The message is delivered to exactly that
+        persona by calling its `process_message()` method.
 
-        Messages from a persona or the system are ignored, to avoid
-        persona-to-persona reply loops.
+        A message is not routed anywhere when it names no target persona, names
+        one that isn't installed in this chat, or is sent by a persona or the
+        system (the last avoids persona-to-persona reply loops).
         """
         if is_persona(message.sender) or message.sender == SYSTEM_USERNAME:
             return
 
-        target_persona = self.get_target_persona(message) or self.active_persona
+        persona_id = (message.metadata or {}).get(self.TO_PERSONA_METADATA_KEY)
+        persona = self.personas.get(persona_id) if persona_id else None
         self.log.debug(
-            "Routing message to persona: %s",
-            target_persona.name if target_persona else None,
+            "Routing message to persona: %s", persona.name if persona else None
         )
-        self._broadcast(
-            message, to_personas=[target_persona] if target_persona else []
-        )
-        return
-
-    def _broadcast(
-        self,
-        message: Message,
-        *,
-        to_personas: list[BasePersona] | dict[str, BasePersona],
-    ) -> None:
-        """
-        Broadcasts a message to all personas in a given list or dictionary.
-        """
-        persona_list: list[BasePersona] = (
-            to_personas if isinstance(to_personas, list) else list(to_personas.values())
-        )
-        for persona in persona_list:
+        if persona:
             self.event_loop.create_task(_safe_process(persona, message))
-        return
 
     async def refresh_personas(self):
         """
@@ -536,10 +450,6 @@ class PersonaManager(LoggingConfigurable):
         # Refresh local personas and re-initialize persona instances
         self._init_local_persona_classes()
         self._personas = self._init_personas()
-
-        # Re-resolve the active persona against the fresh instances, since the
-        # previous instance was just shut down. The id is persisted in metadata.
-        self.active_persona = self._init_active_persona()
 
         # Rebuild avatar cache after reloading personas
         # Get all persona managers from parent (extension) settings

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -420,13 +420,9 @@ class PersonaManager(LoggingConfigurable):
         onto each outgoing message. The message is delivered to exactly that
         persona by calling its `process_message()` method.
 
-        A message is not routed anywhere when it names no target persona, names
-        one that isn't installed in this chat, or is sent by a persona or the
-        system (the last avoids persona-to-persona reply loops).
+        A message is not routed anywhere when it names no target persona or names
+        one that isn't installed in this chat.
         """
-        if is_persona(message.sender) or message.sender == SYSTEM_USERNAME:
-            return
-
         persona_id = (message.metadata or {}).get(self.TO_PERSONA_METADATA_KEY)
         persona = self.personas.get(persona_id) if persona_id else None
         self.log.debug(

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from importlib_metadata import entry_points
 from jupyterlab_chat.models import Message, NewMessage, User
-from traitlets import Bool, List, Unicode, default
+from traitlets import List, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 from .base_persona import BasePersona
@@ -80,21 +80,10 @@ class PersonaManager(LoggingConfigurable):
         default_value="jupyter-ai-personas::jupyter_ai::JupyternautPersona",
         help=""
         "The ID of the default persona. If configured, the default persona "
-        "will automatically reply in a single-user chats until another "
-        "persona is `@`-mentioned. "
+        "replies to messages that don't name a target persona in their "
+        "metadata (until the picker selects someone else). "
         "Defaults to: 'jupyter-ai-personas::jupyter_ai::JupyternautPersona'. ",
         allow_none=True,
-        config=True,
-    )
-
-    mention_updates_active = Bool(
-        default_value=True,
-        help=""
-        "When True, an `@`-mention also sets the active persona that replies to "
-        "subsequent unmentioned messages (the multi-participant model). When "
-        "False, `@`-mentions are ignored for routing and only the active-persona "
-        "selector chooses who replies (the single-active-persona model). "
-        "Defaults to: True. ",
         config=True,
     )
 
@@ -141,10 +130,9 @@ class PersonaManager(LoggingConfigurable):
     base_url: str
     active_persona: BasePersona | None
     """
-    The persona that replies to unmentioned messages in a single-human chat. Set
-    by the active-persona selector or by an `@`-mention (when
-    `mention_updates_active` is True). `None` means no one replies. Initialized
-    from chat metadata, falling back to the default persona.
+    The fallback persona that replies to messages whose metadata names no target
+    persona. Set by the active-persona selector. `None` means no one replies.
+    Initialized from chat metadata, falling back to the default persona.
     """
 
     log: Logger  # type: ignore
@@ -467,59 +455,56 @@ class PersonaManager(LoggingConfigurable):
             self.ACTIVE_PERSONA_METADATA_KEY, persona.id if persona else ""
         )
 
-    def get_mentioned_personas(self, new_message: Message) -> list[BasePersona]:
+    PERSONA_METADATA_KEY = "persona"
+    """
+    Key in a message's `metadata` dict holding the ID of the persona that should
+    reply to it. Stamped onto outgoing messages by the chat input's persona
+    picker.
+    """
+
+    def get_target_persona(self, message: Message) -> BasePersona | None:
         """
-        Returns a list of all personas `@`-mentioned in a chat message, given a
-        reference to the chat message.
+        Returns the persona a message is addressed to, read from its metadata.
+
+        The chat input stamps `metadata["persona"]` with the ID of the selected
+        persona. Returns `None` if the message carries no persona (e.g. an older
+        message or an external client), or if the named persona is not installed
+        in this chat; callers fall back to the active persona in that case.
         """
-        mentioned_ids = set(new_message.mentions or [])
-        persona_list: list[BasePersona] = []
-        for mentioned_id in mentioned_ids:
-            if mentioned_id in self.personas:
-                persona_list.append(self.personas[mentioned_id])
-        return persona_list
+        metadata = message.metadata or {}
+        persona_id = metadata.get(self.PERSONA_METADATA_KEY)
+        if not persona_id:
+            return None
+        return self.personas.get(persona_id)
 
     def on_chat_message(self, room_id: str, message: Message):
         """
-        Method that routes an incoming message to the correct personas by
-        calling their `process_message()` methods.
+        Routes an incoming message to a single persona by calling its
+        `process_message()` method.
 
-        - Messages from a persona or the system only go to explicitly mentioned
-          personas, to avoid persona-to-persona reply loops.
+        The target is read from the message's own metadata
+        (`metadata["persona"]`), which the chat input's persona picker stamps
+        onto each outgoing message. When a message carries no persona — an older
+        message, or one from a client that doesn't set it — we fall back to the
+        chat's active persona (which defaults to `PersonaManager.default_persona`
+        and is `None` when the user has opted out of AI replies).
 
-        - A message from a human goes to the active persona, in single- and
-          multi-human chats alike. An `@`-mention overrides this, replying to
-          the mentioned personas and (when `mention_updates_active`) updating
-          the active persona. Selecting no one (`active_persona is None`) means
-          no one replies, which is how a user opts out of AI replies in a shared
-          chat. The active persona defaults to `PersonaManager.default_persona`.
+        Messages from a persona or the system are ignored, to avoid
+        persona-to-persona reply loops.
         """
-
-        sender_not_human = (
-            is_persona(message.sender) or message.sender == SYSTEM_USERNAME
-        )
-        mentioned_personas = self.get_mentioned_personas(message)
-
-        if sender_not_human:
-            if mentioned_personas:
-                self._broadcast(message, to_personas=mentioned_personas)
+        if is_persona(message.sender) or message.sender == SYSTEM_USERNAME:
             return
 
-        if mentioned_personas and self.mention_updates_active:
-            self.set_active_persona(mentioned_personas[0])
-            targeted_personas = mentioned_personas
-        else:
-            targeted_personas = [self.active_persona] if self.active_persona else []
-
+        target_persona = self.get_target_persona(message) or self.active_persona
         self.log.debug(
-            "Routing message: active=%s, mentioned=%s -> %s",
-            self.active_persona.name if self.active_persona else None,
-            [p.name for p in mentioned_personas],
-            [p.name for p in targeted_personas],
+            "Routing message to persona: %s",
+            target_persona.name if target_persona else None,
         )
-        self._broadcast(message, to_personas=targeted_personas)
+        self._broadcast(
+            message, to_personas=[target_persona] if target_persona else []
+        )
         return
-    
+
     def _broadcast(
         self,
         message: Message,

--- a/jupyter_ai_persona_manager/tests/test_extension.py
+++ b/jupyter_ai_persona_manager/tests/test_extension.py
@@ -3,7 +3,7 @@ Tests for the PersonaManagerExtension class.
 """
 
 import pytest
-from unittest.mock import Mock, AsyncMock
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 from jupyter_ai_persona_manager.extension import PersonaManagerExtension
 
 
@@ -79,3 +79,51 @@ async def test_stop_extension_without_jupyter_ai_settings(extension, mock_server
 
     # Should not raise an exception
     await extension.stop_extension()
+
+
+from traitlets.config import Config
+
+from jupyter_ai_persona_manager.persona_manager import PersonaManager
+
+
+class TestDefaultPersonaId:
+    """The default persona ID resolved for the frontend PageConfig."""
+
+    def test_uses_the_trait_default_when_not_configured(self, extension):
+        assert (
+            extension._default_persona_id()
+            == PersonaManager.default_persona_id.default_value
+        )
+
+    def test_uses_a_user_configured_override(self, extension):
+        extension.config = Config(
+            {"PersonaManager": {"default_persona_id": "pkg::Custom"}}
+        )
+        assert extension._default_persona_id() == "pkg::Custom"
+
+    def test_returns_empty_string_when_default_is_disabled(self, extension):
+        # `default_persona_id` allows None to disable the default persona.
+        extension.config = Config({"PersonaManager": {"default_persona_id": None}})
+        assert extension._default_persona_id() == ""
+
+
+def test_initialize_settings_advertises_default_persona(extension, mock_server_app):
+    """initialize_settings writes the default persona ID into page_config_data
+    so the frontend can read it at startup."""
+    # `self.settings` mirrors the web app settings for an ExtensionApp; provide
+    # it so the method can seed the persona-managers dict.
+    extension.settings = mock_server_app.web_app.settings
+    # `initialize_settings` kicks off a router-integration task on the event
+    # loop; stub the loop (a read-only property) and the coroutine it schedules
+    # so the test needs no running loop.
+    with patch.object(
+        type(extension), "event_loop", new_callable=PropertyMock
+    ) as event_loop, patch.object(extension, "_setup_router_integration"):
+        event_loop.return_value = Mock()
+        extension.initialize_settings()
+
+    page_config = mock_server_app.web_app.settings["page_config_data"]
+    assert (
+        page_config["jupyter_ai_default_persona"]
+        == PersonaManager.default_persona_id.default_value
+    )

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -2,9 +2,10 @@
 Test the persona manager functionality.
 """
 
+import logging
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from jupyterlab_chat.models import Message
@@ -211,17 +212,16 @@ PERSONA_SENDER = "jupyter-ai-personas::pkg::Bot"
 HUMAN_SENDER = "human-1"
 
 
-def _routing_manager(active_persona=None, personas=None):
+def _routing_manager(personas=None):
     """A PersonaManager with only the state on_chat_message routing reads.
 
     Uses ``__new__`` to get the traitlets machinery without the heavy ``__init__``
     (which loads personas), then sets just the attributes routing touches.
     """
     pm = PersonaManager.__new__(PersonaManager)
-    pm.active_persona = active_persona
     pm._personas = personas or {}
-    pm.ychat = Mock()
-    pm._broadcast = Mock()
+    pm.log = logging.getLogger("test-persona-manager")
+    pm.event_loop = Mock()
     return pm
 
 
@@ -232,155 +232,54 @@ def _message(sender, metadata=None):
     return message
 
 
-def _replied_to(pm):
-    """The personas on_chat_message decided should reply."""
-    return pm._broadcast.call_args.kwargs["to_personas"]
-
-
 class TestOnChatMessageRouting:
-    """Who replies to a message. Asserts on the routing decision (the persona
-    list handed to delivery), not on how delivery happens."""
+    """Who a message is routed to. Patches ``_safe_process`` (the per-persona
+    delivery coroutine) to assert which persona a message reaches."""
+
+    def _route(self, pm, message):
+        """Run routing with ``_safe_process`` patched; return the personas it
+        was called with."""
+        # Patch with a plain (non-async) mock so no coroutine is created — the
+        # real `_safe_process` is a coroutine function, and we don't run it here.
+        with patch(
+            "jupyter_ai_persona_manager.persona_manager._safe_process",
+            new=MagicMock(),
+        ) as safe_process:
+            pm.on_chat_message("room", message)
+        return [call.args[0] for call in safe_process.call_args_list]
 
     def test_routes_to_the_persona_named_in_metadata(self):
         target = _make_mock_persona()
-        active = _make_mock_persona()
-        pm = _routing_manager(active_persona=active, personas={"p1": target})
-
-        pm.on_chat_message("room", _message(HUMAN_SENDER, {"persona": "p1"}))
-
-        assert _replied_to(pm) == [target]
-
-    def test_falls_back_to_active_persona_when_metadata_has_no_persona(self):
-        active = _make_mock_persona()
-        pm = _routing_manager(active_persona=active)
-
-        pm.on_chat_message("room", _message(HUMAN_SENDER, metadata=None))
-
-        assert _replied_to(pm) == [active]
-
-    def test_falls_back_to_active_persona_when_named_persona_is_unknown(self):
-        active = _make_mock_persona()
-        pm = _routing_manager(active_persona=active, personas={})
-
-        pm.on_chat_message("room", _message(HUMAN_SENDER, {"persona": "gone"}))
-
-        assert _replied_to(pm) == [active]
-
-    def test_no_active_persona_and_no_metadata_means_no_one_replies(self):
-        pm = _routing_manager(active_persona=None)
-
-        pm.on_chat_message("room", _message(HUMAN_SENDER, metadata=None))
-
-        assert _replied_to(pm) == []
-
-    def test_metadata_persona_wins_over_active_persona(self):
-        target = _make_mock_persona()
-        active = _make_mock_persona()
-        pm = _routing_manager(active_persona=active, personas={"p1": target})
-
-        pm.on_chat_message("room", _message(HUMAN_SENDER, {"persona": "p1"}))
-
-        assert _replied_to(pm) == [target]
-        # Routing by metadata does not mutate the active persona.
-        assert pm.active_persona is active
-
-    def test_persona_sender_is_ignored(self):
-        pm = _routing_manager(
-            active_persona=_make_mock_persona(),
-            personas={"p1": _make_mock_persona()},
-        )
-
-        pm.on_chat_message("room", _message(PERSONA_SENDER, {"persona": "p1"}))
-
-        pm._broadcast.assert_not_called()
-
-    def test_system_sender_is_ignored(self):
-        pm = _routing_manager(
-            active_persona=_make_mock_persona(),
-            personas={"p1": _make_mock_persona()},
-        )
-
-        pm.on_chat_message("room", _message(SYSTEM_USERNAME, {"persona": "p1"}))
-
-        pm._broadcast.assert_not_called()
-
-
-class TestGetTargetPersona:
-    """Reading the addressed persona from a message's metadata."""
-
-    def test_returns_the_persona_named_in_metadata(self):
-        target = _make_mock_persona()
         pm = _routing_manager(personas={"p1": target})
 
-        assert pm.get_target_persona(_message(HUMAN_SENDER, {"persona": "p1"})) is target
+        routed = self._route(pm, _message(HUMAN_SENDER, {"to_persona": "p1"}))
 
-    def test_returns_none_when_metadata_is_missing(self):
+        assert routed == [target]
+
+    def test_no_target_persona_means_no_one_is_routed_to(self):
         pm = _routing_manager(personas={"p1": _make_mock_persona()})
 
-        assert pm.get_target_persona(_message(HUMAN_SENDER, metadata=None)) is None
+        routed = self._route(pm, _message(HUMAN_SENDER, metadata=None))
 
-    def test_returns_none_when_metadata_has_no_persona(self):
+        assert routed == []
+
+    def test_unknown_target_persona_means_no_one_is_routed_to(self):
         pm = _routing_manager(personas={"p1": _make_mock_persona()})
 
-        assert pm.get_target_persona(_message(HUMAN_SENDER, {"other": "x"})) is None
+        routed = self._route(pm, _message(HUMAN_SENDER, {"to_persona": "gone"}))
 
-    def test_returns_none_when_named_persona_is_unknown(self):
-        pm = _routing_manager(personas={})
+        assert routed == []
 
-        assert pm.get_target_persona(_message(HUMAN_SENDER, {"persona": "gone"})) is None
+    def test_persona_sender_is_ignored(self):
+        pm = _routing_manager(personas={"p1": _make_mock_persona()})
 
+        routed = self._route(pm, _message(PERSONA_SENDER, {"to_persona": "p1"}))
 
-class TestActivePersonaResolution:
-    """How the active persona is resolved at startup (_init_active_persona)."""
+        assert routed == []
 
-    def _manager(self, *, metadata, personas, default_id=""):
-        pm = PersonaManager.__new__(PersonaManager)
-        pm.default_persona_id = default_id
-        pm.room_id = "room"
-        pm._personas = personas
-        pm.ychat = Mock()
-        pm.ychat.get_metadata.return_value = metadata
-        return pm
+    def test_system_sender_is_ignored(self):
+        pm = _routing_manager(personas={"p1": _make_mock_persona()})
 
-    def test_uses_the_stored_active_persona_when_it_still_exists(self):
-        stored = _make_mock_persona()
-        pm = self._manager(metadata={"active_persona_id": "p1"}, personas={"p1": stored})
+        routed = self._route(pm, _message(SYSTEM_USERNAME, {"to_persona": "p1"}))
 
-        assert pm._init_active_persona() is stored
-
-    def test_empty_stored_value_means_no_one(self):
-        pm = self._manager(
-            metadata={"active_persona_id": ""}, personas={"p1": _make_mock_persona()}
-        )
-
-        assert pm._init_active_persona() is None
-
-    def test_falls_back_to_default_when_the_stored_persona_is_gone(self):
-        default = _make_mock_persona()
-        pm = self._manager(
-            metadata={"active_persona_id": "gone"},
-            personas={"d": default},
-            default_id="d",
-        )
-
-        assert pm._init_active_persona() is default
-
-    def test_uses_the_default_persona_when_nothing_is_stored(self):
-        default = _make_mock_persona()
-        pm = self._manager(metadata={}, personas={"d": default}, default_id="d")
-
-        assert pm._init_active_persona() is default
-
-    def test_uses_the_sole_persona_when_no_default_and_only_one(self):
-        only = _make_mock_persona()
-        pm = self._manager(metadata={}, personas={"only": only})
-
-        assert pm._init_active_persona() is only
-
-    def test_no_one_when_no_default_and_several_personas(self):
-        pm = self._manager(
-            metadata={},
-            personas={"a": _make_mock_persona(), "b": _make_mock_persona()},
-        )
-
-        assert pm._init_active_persona() is None
+        assert routed == []

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -211,24 +211,24 @@ PERSONA_SENDER = "jupyter-ai-personas::pkg::Bot"
 HUMAN_SENDER = "human-1"
 
 
-def _routing_manager(active_persona=None, mention_updates_active=True):
+def _routing_manager(active_persona=None, personas=None):
     """A PersonaManager with only the state on_chat_message routing reads.
 
     Uses ``__new__`` to get the traitlets machinery without the heavy ``__init__``
     (which loads personas), then sets just the attributes routing touches.
     """
     pm = PersonaManager.__new__(PersonaManager)
-    pm.mention_updates_active = mention_updates_active
     pm.active_persona = active_persona
+    pm._personas = personas or {}
     pm.ychat = Mock()
-    pm.get_mentioned_personas = Mock(return_value=[])
     pm._broadcast = Mock()
     return pm
 
 
-def _message(sender):
+def _message(sender, metadata=None):
     message = Mock(spec=Message)
     message.sender = sender
+    message.metadata = metadata
     return message
 
 
@@ -241,65 +241,93 @@ class TestOnChatMessageRouting:
     """Who replies to a message. Asserts on the routing decision (the persona
     list handed to delivery), not on how delivery happens."""
 
-    def test_human_message_goes_to_the_active_persona(self):
+    def test_routes_to_the_persona_named_in_metadata(self):
+        target = _make_mock_persona()
+        active = _make_mock_persona()
+        pm = _routing_manager(active_persona=active, personas={"p1": target})
+
+        pm.on_chat_message("room", _message(HUMAN_SENDER, {"persona": "p1"}))
+
+        assert _replied_to(pm) == [target]
+
+    def test_falls_back_to_active_persona_when_metadata_has_no_persona(self):
         active = _make_mock_persona()
         pm = _routing_manager(active_persona=active)
 
-        pm.on_chat_message("room", _message(HUMAN_SENDER))
+        pm.on_chat_message("room", _message(HUMAN_SENDER, metadata=None))
 
         assert _replied_to(pm) == [active]
 
-    def test_mention_replies_to_the_mentioned_persona_and_makes_it_active(self):
-        mentioned = _make_mock_persona()
-        pm = _routing_manager(active_persona=None, mention_updates_active=True)
-        pm.get_mentioned_personas = Mock(return_value=[mentioned])
-
-        pm.on_chat_message("room", _message(HUMAN_SENDER))
-
-        assert _replied_to(pm) == [mentioned]
-        assert pm.active_persona is mentioned
-
-    def test_mention_is_ignored_for_routing_when_flag_is_off(self):
+    def test_falls_back_to_active_persona_when_named_persona_is_unknown(self):
         active = _make_mock_persona()
-        mentioned = _make_mock_persona()
-        pm = _routing_manager(active_persona=active, mention_updates_active=False)
-        pm.get_mentioned_personas = Mock(return_value=[mentioned])
+        pm = _routing_manager(active_persona=active, personas={})
 
-        pm.on_chat_message("room", _message(HUMAN_SENDER))
+        pm.on_chat_message("room", _message(HUMAN_SENDER, {"persona": "gone"}))
 
         assert _replied_to(pm) == [active]
-        assert pm.active_persona is active
 
-    def test_no_active_persona_means_no_one_replies(self):
+    def test_no_active_persona_and_no_metadata_means_no_one_replies(self):
         pm = _routing_manager(active_persona=None)
 
-        pm.on_chat_message("room", _message(HUMAN_SENDER))
+        pm.on_chat_message("room", _message(HUMAN_SENDER, metadata=None))
 
         assert _replied_to(pm) == []
 
-    def test_persona_sender_without_mention_is_ignored(self):
-        pm = _routing_manager(active_persona=_make_mock_persona())
-
-        pm.on_chat_message("room", _message(PERSONA_SENDER))
-
-        pm._broadcast.assert_not_called()
-
-    def test_persona_sender_with_mention_replies_to_the_mentioned_persona(self):
+    def test_metadata_persona_wins_over_active_persona(self):
+        target = _make_mock_persona()
         active = _make_mock_persona()
-        mentioned = _make_mock_persona()
-        pm = _routing_manager(active_persona=active)
-        pm.get_mentioned_personas = Mock(return_value=[mentioned])
+        pm = _routing_manager(active_persona=active, personas={"p1": target})
 
-        pm.on_chat_message("room", _message(PERSONA_SENDER))
+        pm.on_chat_message("room", _message(HUMAN_SENDER, {"persona": "p1"}))
 
-        assert _replied_to(pm) == [mentioned]
+        assert _replied_to(pm) == [target]
+        # Routing by metadata does not mutate the active persona.
+        assert pm.active_persona is active
 
-    def test_system_sender_without_mention_is_ignored(self):
-        pm = _routing_manager(active_persona=_make_mock_persona())
+    def test_persona_sender_is_ignored(self):
+        pm = _routing_manager(
+            active_persona=_make_mock_persona(),
+            personas={"p1": _make_mock_persona()},
+        )
 
-        pm.on_chat_message("room", _message(SYSTEM_USERNAME))
+        pm.on_chat_message("room", _message(PERSONA_SENDER, {"persona": "p1"}))
 
         pm._broadcast.assert_not_called()
+
+    def test_system_sender_is_ignored(self):
+        pm = _routing_manager(
+            active_persona=_make_mock_persona(),
+            personas={"p1": _make_mock_persona()},
+        )
+
+        pm.on_chat_message("room", _message(SYSTEM_USERNAME, {"persona": "p1"}))
+
+        pm._broadcast.assert_not_called()
+
+
+class TestGetTargetPersona:
+    """Reading the addressed persona from a message's metadata."""
+
+    def test_returns_the_persona_named_in_metadata(self):
+        target = _make_mock_persona()
+        pm = _routing_manager(personas={"p1": target})
+
+        assert pm.get_target_persona(_message(HUMAN_SENDER, {"persona": "p1"})) is target
+
+    def test_returns_none_when_metadata_is_missing(self):
+        pm = _routing_manager(personas={"p1": _make_mock_persona()})
+
+        assert pm.get_target_persona(_message(HUMAN_SENDER, metadata=None)) is None
+
+    def test_returns_none_when_metadata_has_no_persona(self):
+        pm = _routing_manager(personas={"p1": _make_mock_persona()})
+
+        assert pm.get_target_persona(_message(HUMAN_SENDER, {"other": "x"})) is None
+
+    def test_returns_none_when_named_persona_is_unknown(self):
+        pm = _routing_manager(personas={})
+
+        assert pm.get_target_persona(_message(HUMAN_SENDER, {"persona": "gone"})) is None
 
 
 class TestActivePersonaResolution:

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -270,16 +270,13 @@ class TestOnChatMessageRouting:
 
         assert routed == []
 
-    def test_persona_sender_is_ignored(self):
-        pm = _routing_manager(personas={"p1": _make_mock_persona()})
+    def test_routes_by_metadata_regardless_of_sender(self):
+        # Routing keys only on `to_persona`; the sender is not consulted. A
+        # persona addressing another persona via metadata is explicit and
+        # intentional, so there is no sender-based guard.
+        target = _make_mock_persona()
+        pm = _routing_manager(personas={"p1": target})
 
-        routed = self._route(pm, _message(PERSONA_SENDER, {"to_persona": "p1"}))
-
-        assert routed == []
-
-    def test_system_sender_is_ignored(self):
-        pm = _routing_manager(personas={"p1": _make_mock_persona()})
-
-        routed = self._route(pm, _message(SYSTEM_USERNAME, {"to_persona": "p1"}))
-
-        assert routed == []
+        for sender in (PERSONA_SENDER, SYSTEM_USERNAME):
+            routed = self._route(pm, _message(sender, {"to_persona": "p1"}))
+            assert routed == [target]


### PR DESCRIPTION
## Motivation

Previously, messages were routed to AI personas based on `@`-mentions inside of the message body. When an AI persona was `@`-mentioned, it would always respond. The last-mentioned persona would also automatically respond but only if a single human user was connected to the chat. Users found it annoying to constantly `@`-mention personas to get them to reply consistently, and frequently asked why AI personas stopped auto-responding in multi-user RTC environments.

There were also a couple of other problems:

- When multiple AI personas were `@`-mentioned, they would respond in parallel. This is almost never a user's intention, and people found this behavior confusing. The multi-persona invocation story was never finished, and this is a quirk of Jupyter AI v3.0.

- When an AI persona referred to another AI persona by name (e.g. "I don't know the answer to that, but perhaps `@Kiro` knows"), it could trigger an infinite loop. It was too easy to accidentally mention other AI personas.

## Summary

Routing is now as simple as it should be: each chat message carries the ID of the persona it's directed to in its own metadata (`metadata["to_persona"]`). By making this field per-message, different users can have different AI personas configured in the same chat, allowing for seamless collaboration that doesn't rely on guessing internal state like the last active/mentioned/default persona. This mostly reverts #54 as a result.

**The new UI contract:** the persona in the persona picker UI that a user sees is **always** the one that responds to their messages, regardless of whether they have other peers connected or not.

## Technical details

- The default persona configurable trait now just sets `PageConfig` data that tells the UI to have a persona pre-selected.

- Multi-persona invocation has been disabled as there is no clear story for this. Even for multi-agent orchestration features we are planning, this seems unnecessary as it generally always makes sense to work with a single orchestrator/planner before starting a workflow.

- Personas can now `@`-mention each other. Infinite loops are avoided by design as personas must explicitly define and configure support for mentioning other AI personas.

- This requires an upstream change in Jupyter Chat (jupyterlab/jupyter-chat#465) and a downstream change in the persona picker UI living in `jupyter-ai-acp-client` (jupyter-ai-contrib/jupyter-ai-acp-client#135), which will eventually be moved here.

## Testing

- Replaced existing unit tests with ones that assert the new message-based routing introduced here.