### PR TITLE
Do not hide `node_modules` by default

### DIFF
--- a/jupyter_ai_persona_manager/extension.py
+++ b/jupyter_ai_persona_manager/extension.py
@@ -286,7 +286,6 @@ class PersonaManagerExtension(ExtensionApp):
             ".git",  # Git version control directory
             ".venv",  # Python virtual environment directory
             "venv",  # Python virtual environment directory
-            "node_modules",  # Node.js dependencies directory
             ".pytest_cache",  # PyTest cache directory
             ".mypy_cache",  # MyPy type checker cache directory
             "*.egg-info",  # Python package metadata directories

--- a/jupyter_ai_persona_manager/tests/test_extension.py
+++ b/jupyter_ai_persona_manager/tests/test_extension.py
@@ -127,3 +127,31 @@ def test_initialize_settings_advertises_default_persona(extension, mock_server_a
         page_config["jupyter_ai_default_persona"]
         == PersonaManager.default_persona_id.default_value
     )
+
+
+class TestLinkJupyterServerExtension:
+    """The ContentsManager config applied when the extension is linked."""
+
+    def _apply_config(self, extension, mock_server_app):
+        """Run _link_jupyter_server_extension and return the applied Config."""
+        # The base class hook has unrelated side effects; stub it out so the
+        # test isolates this extension's own config contribution.
+        with patch(
+            "jupyter_ai_persona_manager.extension.ExtensionApp._link_jupyter_server_extension"
+        ):
+            extension._link_jupyter_server_extension(mock_server_app)
+        # The Config is passed to server_app.update_config(c).
+        (applied_config,), _ = mock_server_app.update_config.call_args
+        return applied_config
+
+    def test_hide_globs_does_not_hide_node_modules(self, extension, mock_server_app):
+        # node_modules is a real dependency directory users expect to browse; it
+        # must not be in the curated hide_globs list.
+        config = self._apply_config(extension, mock_server_app)
+        assert "node_modules" not in config.ContentsManager.hide_globs
+
+    def test_hide_globs_still_hides_noise(self, extension, mock_server_app):
+        # The rest of the curated list is unchanged.
+        config = self._apply_config(extension, mock_server_app)
+        assert "__pycache__" in config.ContentsManager.hide_globs
+        assert config.ContentsManager.allow_hidden is True


### PR DESCRIPTION
## Motivation

`hide_globs` was extended here so the `.jupyter/` folder and common noise directories stay out of file listings. `node_modules` was included in that list.

Unlike dotfiles (which `allow_hidden` gates), `node_modules` is an ordinary directory name, so the only thing hiding it is its presence in `hide_globs`. There is no per-deployment way to bring it back short of overriding the whole list.

## Summary

Drops `node_modules` from the curated `hide_globs` list so it shows up in file and directory listings again. The rest of the list (bytecode caches, editor backups, VCS metadata, etc.) is unchanged.