### PR TITLE
Add optional BasePersona.cancel_response() to interrupt a reply

### DIFF
--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import html
 import os
 import traceback
@@ -100,6 +101,14 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
     Automatically set by `BasePersona`.
     """
 
+    _processing_count: int
+    """
+    Number of messages this persona is currently processing. Incremented while a
+    `process_message()` call is in flight and decremented when it finishes (see
+    `track_processing`). A count because a persona can process several messages
+    concurrently. Exposed read-only via the `processing` property.
+    """
+
     ################################################
     # constructor
     ################################################
@@ -114,6 +123,7 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
 
         # Bind arguments to instance attributes
         self.ychat = ychat
+        self._processing_count = 0
 
         # Initialize this persona's awareness slot. It starts with a default
         # (empty) session state already published; the persona fills in its
@@ -166,7 +176,37 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         nothing cancellable or complete their responses synchronously. A persona
         that streams or runs a long-lived turn (e.g. an ACP agent) overrides this
         to actually interrupt it.
+
+        An override should first check `self.processing` and return early when
+        nothing is in flight — some backends treat a cancel with no active
+        response as an error (e.g. ACP defines `session/cancel` only for an
+        ongoing prompt turn). Callers should also gate on `processing` (see the
+        cancel handler), but a direct caller may not, so guard here too.
         """
+
+    @property
+    def processing(self) -> bool:
+        """
+        Whether this persona is currently processing at least one message — i.e.
+        a `process_message()` call is in flight. Use this to avoid interrupting a
+        persona that has no response to cancel (see `cancel_response`).
+        """
+        return self._processing_count > 0
+
+    @contextlib.contextmanager
+    def track_processing(self):
+        """
+        Context manager that marks this persona as processing for its duration,
+        so `processing` reflects an in-flight response. `PersonaManager` wraps
+        each `process_message()` call in this; the count is restored even if the
+        call raises. A count (not a bool) because a persona may process several
+        messages concurrently.
+        """
+        self._processing_count += 1
+        try:
+            yield
+        finally:
+            self._processing_count -= 1
 
     ################################################
     # base class methods, available to subclasses.

--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -177,11 +177,11 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         that streams or runs a long-lived turn (e.g. an ACP agent) overrides this
         to actually interrupt it.
 
-        An override should first check `self.processing` and return early when
-        nothing is in flight — some backends treat a cancel with no active
+        Only invoked for a persona that's currently `processing` — the cancel
+        handler gates on that — so an override can assume a response is in
+        flight. This matters because some backends treat a cancel with no active
         response as an error (e.g. ACP defines `session/cancel` only for an
-        ongoing prompt turn). Callers should also gate on `processing` (see the
-        cancel handler), but a direct caller may not, so guard here too.
+        ongoing prompt turn).
         """
 
     @property

--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -151,6 +151,23 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         This is an abstract method that must be implemented by subclasses.
         """
 
+    async def cancel_response(self) -> None:
+        """
+        Stops this persona's in-progress response, if any. Called when the user
+        interrupts the persona from the chat UI.
+
+        This is the counterpart to `process_message`: it should halt whatever
+        that method set in motion (a model stream, an agent turn, pending tool
+        calls) so the persona stops writing to the chat promptly. `stream_message`
+        already clears the `is_writing` awareness flag when it unwinds, so a
+        subclass typically just needs to interrupt its own backend here.
+
+        Optional: the default implementation is a no-op, for personas that have
+        nothing cancellable or complete their responses synchronously. A persona
+        that streams or runs a long-lived turn (e.g. an ACP agent) overrides this
+        to actually interrupt it.
+        """
+
     ################################################
     # base class methods, available to subclasses.
     ################################################

--- a/jupyter_ai_persona_manager/extension.py
+++ b/jupyter_ai_persona_manager/extension.py
@@ -13,6 +13,7 @@ from traitlets.config import Config
 
 from jupyter_ai_persona_manager.handlers import (
     AvatarHandler,
+    CancelHandler,
     MessageHandler,
     build_avatar_cache,
 )
@@ -37,6 +38,7 @@ class PersonaManagerExtension(ExtensionApp):
     handlers = [
         (r"/api/ai/avatars/(.*)", AvatarHandler),
         (r"/api/ai/message/(.*)", MessageHandler),
+        (r"/api/ai/personas/cancel", CancelHandler),
     ]
     
     persona_manager_class = Type(

--- a/jupyter_ai_persona_manager/handlers.py
+++ b/jupyter_ai_persona_manager/handlers.py
@@ -143,6 +143,58 @@ class MessageHandler(JupyterHandler):
         self.finish(json.dumps({"response": response}))
 
 
+class CancelHandler(JupyterHandler):
+    """
+    Handler to cancel personas' in-progress responses in a chat.
+
+    The frontend POSTs here (with the chat's path as a query parameter) when the
+    user interrupts. Each persona in the chat is asked to stop via
+    `BasePersona.cancel_response()`, which halts whatever its reply set in motion
+    (a model stream, an agent turn, pending tool calls). Backend-agnostic: a
+    persona with nothing cancellable inherits the base no-op.
+    """
+
+    @property
+    def file_id_manager(self):
+        manager = self.serverapp.web_app.settings.get("file_id_manager")
+        if manager is None:
+            raise tornado.web.HTTPError(500, "file_id_manager is not available")
+        return manager
+
+    @tornado.web.authenticated
+    async def post(self):
+        chat_path = self.get_argument("chat_path", None)
+        if not chat_path:
+            raise tornado.web.HTTPError(
+                400, "chat_path is required as a URL query parameter"
+            )
+
+        file_id = self.file_id_manager.get_id(chat_path)
+        if not file_id:
+            raise tornado.web.HTTPError(404, f"Chat not found: {chat_path}")
+        room_id = f"text:chat:{file_id}"
+
+        persona_manager = (
+            self.serverapp.web_app.settings.get("jupyter-ai", {})
+            .get("persona-managers", {})
+            .get(room_id)
+        )
+        if not persona_manager:
+            raise tornado.web.HTTPError(404, f"Chat not initialized: {chat_path}")
+
+        cancelled = []
+        for persona in persona_manager.personas.values():
+            try:
+                await persona.cancel_response()
+                cancelled.append(persona.id)
+            except Exception:
+                self.log.warning(
+                    f"Failed to cancel response for persona '{persona.id}'",
+                    exc_info=True,
+                )
+        self.finish(json.dumps({"status": "cancelled", "cancelled": cancelled}))
+
+
 class AvatarHandler(JupyterHandler):
     """
     Handler for serving persona avatar files.

--- a/jupyter_ai_persona_manager/handlers.py
+++ b/jupyter_ai_persona_manager/handlers.py
@@ -184,6 +184,11 @@ class CancelHandler(JupyterHandler):
 
         cancelled = []
         for persona in persona_manager.personas.values():
+            # Only interrupt personas that are actually processing a response;
+            # cancelling an idle persona may be out of spec for some backends
+            # (e.g. ACP's session/cancel is defined only for an ongoing turn).
+            if not persona.processing:
+                continue
             try:
                 await persona.cancel_response()
                 cancelled.append(persona.id)

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -66,7 +66,8 @@ async def _safe_process(persona: "BasePersona", message: Message) -> None:
     """
     try:
         await persona.apply_specs_in_message(message)
-        await persona.process_message(message)
+        with persona.track_processing():
+            await persona.process_message(message)
     except Exception as exc:
         persona.log.error(
             f"Persona '{persona.name}' raised an unhandled exception in process_message()."

--- a/jupyter_ai_persona_manager/tests/test_base_persona.py
+++ b/jupyter_ai_persona_manager/tests/test_base_persona.py
@@ -44,6 +44,7 @@ def _make_persona(mock_ychat):
     persona.ychat = mock_ychat
     persona.log = MagicMock()
     persona.awareness = MagicMock()
+    persona._processing_count = 0
     return persona
 
 
@@ -197,3 +198,37 @@ class TestCancelResponse:
         await persona.cancel_response()
 
         assert cancelled is True
+
+
+# ---------------------------------------------------------------------------
+# TestProcessing
+# ---------------------------------------------------------------------------
+
+class TestProcessing:
+
+    def test_not_processing_by_default(self, mock_ychat):
+        persona = _make_persona(mock_ychat)
+        assert persona.processing is False
+
+    def test_track_processing_toggles_flag(self, mock_ychat):
+        persona = _make_persona(mock_ychat)
+        with persona.track_processing():
+            assert persona.processing is True
+        assert persona.processing is False
+
+    def test_track_processing_is_reentrant(self, mock_ychat):
+        # Concurrent messages: the count, not a bool, keeps `processing` true
+        # until the last one finishes.
+        persona = _make_persona(mock_ychat)
+        with persona.track_processing():
+            with persona.track_processing():
+                assert persona.processing is True
+            assert persona.processing is True
+        assert persona.processing is False
+
+    def test_track_processing_restores_on_exception(self, mock_ychat):
+        persona = _make_persona(mock_ychat)
+        with pytest.raises(ValueError):
+            with persona.track_processing():
+                raise ValueError("boom")
+        assert persona.processing is False

--- a/jupyter_ai_persona_manager/tests/test_base_persona.py
+++ b/jupyter_ai_persona_manager/tests/test_base_persona.py
@@ -158,3 +158,42 @@ class TestStreamMessageReRaise:
 
         # The `finally` clears the writing status via the awareness property.
         assert persona.awareness.is_writing is False
+
+
+# ---------------------------------------------------------------------------
+# TestCancelResponse
+# ---------------------------------------------------------------------------
+
+class TestCancelResponse:
+
+    @pytest.mark.asyncio
+    async def test_default_is_a_noop(self, mock_ychat):
+        # The base implementation is optional: awaiting it does nothing and does
+        # not touch the chat or awareness. A persona with nothing cancellable
+        # inherits this.
+        persona = _make_persona(mock_ychat)
+
+        await persona.cancel_response()
+
+        mock_ychat.add_message.assert_not_called()
+        mock_ychat.update_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_subclass_can_override(self, mock_ychat):
+        # A streaming/long-running persona overrides cancel_response to interrupt
+        # its backend; PersonaManager calls it the same way regardless.
+        cancelled = False
+
+        class _CancellablePersona(_ConcretePersona):
+            async def cancel_response(self) -> None:
+                nonlocal cancelled
+                cancelled = True
+
+        persona = _CancellablePersona.__new__(_CancellablePersona)
+        persona.ychat = mock_ychat
+        persona.log = MagicMock()
+        persona.awareness = MagicMock()
+
+        await persona.cancel_response()
+
+        assert cancelled is True

--- a/jupyter_ai_persona_manager/tests/test_handlers.py
+++ b/jupyter_ai_persona_manager/tests/test_handlers.py
@@ -109,3 +109,78 @@ async def test_avatar_handler_serves_png(jp_fetch, jp_serverapp, tmp_path):
     assert 'image/png' in response.headers.get('Content-Type', '')
 
 
+
+
+# ---------------------------------------------------------------------------
+# CancelHandler
+# ---------------------------------------------------------------------------
+
+
+def _install_cancel_fixtures(jp_serverapp, chat_path, room_id, personas):
+    """Wire a mock file_id_manager (chat_path -> file id) and a persona manager
+    (room_id -> personas) into the server settings for a cancel request."""
+    from unittest.mock import Mock
+
+    # file id manager: chat_path -> file id, so room_id = text:chat:<file id>.
+    file_id = room_id.split(":")[-1]
+    mock_fim = Mock()
+    mock_fim.get_id.return_value = file_id
+    jp_serverapp.web_app.settings["file_id_manager"] = mock_fim
+
+    mock_pm = Mock()
+    mock_pm.personas = personas
+    settings = jp_serverapp.web_app.settings.setdefault("jupyter-ai", {})
+    settings["persona-managers"] = {room_id: mock_pm}
+
+
+async def test_cancel_handler_calls_cancel_response(jp_fetch, jp_serverapp):
+    """A POST cancels every persona in the chat via cancel_response()."""
+    from unittest.mock import AsyncMock, Mock
+
+    persona = Mock()
+    persona.id = "jupyter-ai-personas::test::TestPersona"
+    persona.cancel_response = AsyncMock()
+
+    _install_cancel_fixtures(
+        jp_serverapp, "notebooks/chat.chat", "text:chat:file-1", {"p": persona}
+    )
+
+    response = await jp_fetch(
+        "api", "ai", "personas", "cancel",
+        method="POST", body="",
+        params={"chat_path": "notebooks/chat.chat"},
+    )
+
+    assert response.code == 200
+    body = json.loads(response.body)
+    assert body["status"] == "cancelled"
+    assert persona.id in body["cancelled"]
+    persona.cancel_response.assert_awaited_once()
+
+
+async def test_cancel_handler_requires_chat_path(jp_fetch):
+    """Missing chat_path is a 400."""
+    from tornado.httpclient import HTTPClientError
+
+    with pytest.raises(HTTPClientError) as exc:
+        await jp_fetch("api", "ai", "personas", "cancel", method="POST", body="")
+    assert exc.value.code == 400
+
+
+async def test_cancel_handler_404_for_uninitialized_chat(jp_fetch, jp_serverapp):
+    """A chat with no persona manager is a 404."""
+    from tornado.httpclient import HTTPClientError
+    from unittest.mock import Mock
+
+    mock_fim = Mock()
+    mock_fim.get_id.return_value = "file-unknown"
+    jp_serverapp.web_app.settings["file_id_manager"] = mock_fim
+    jp_serverapp.web_app.settings.setdefault("jupyter-ai", {})["persona-managers"] = {}
+
+    with pytest.raises(HTTPClientError) as exc:
+        await jp_fetch(
+            "api", "ai", "personas", "cancel",
+            method="POST", body="",
+            params={"chat_path": "notebooks/chat.chat"},
+        )
+    assert exc.value.code == 404

--- a/jupyter_ai_persona_manager/tests/test_handlers.py
+++ b/jupyter_ai_persona_manager/tests/test_handlers.py
@@ -134,11 +134,12 @@ def _install_cancel_fixtures(jp_serverapp, chat_path, room_id, personas):
 
 
 async def test_cancel_handler_calls_cancel_response(jp_fetch, jp_serverapp):
-    """A POST cancels every persona in the chat via cancel_response()."""
+    """A POST cancels each processing persona in the chat via cancel_response()."""
     from unittest.mock import AsyncMock, Mock
 
     persona = Mock()
     persona.id = "jupyter-ai-personas::test::TestPersona"
+    persona.processing = True
     persona.cancel_response = AsyncMock()
 
     _install_cancel_fixtures(
@@ -156,6 +157,40 @@ async def test_cancel_handler_calls_cancel_response(jp_fetch, jp_serverapp):
     assert body["status"] == "cancelled"
     assert persona.id in body["cancelled"]
     persona.cancel_response.assert_awaited_once()
+
+
+async def test_cancel_handler_skips_idle_personas(jp_fetch, jp_serverapp):
+    """A persona that isn't processing is left alone — no cancel_response call."""
+    from unittest.mock import AsyncMock, Mock
+
+    idle = Mock()
+    idle.id = "jupyter-ai-personas::test::IdlePersona"
+    idle.processing = False
+    idle.cancel_response = AsyncMock()
+
+    busy = Mock()
+    busy.id = "jupyter-ai-personas::test::BusyPersona"
+    busy.processing = True
+    busy.cancel_response = AsyncMock()
+
+    _install_cancel_fixtures(
+        jp_serverapp,
+        "notebooks/chat.chat",
+        "text:chat:file-1",
+        {"idle": idle, "busy": busy},
+    )
+
+    response = await jp_fetch(
+        "api", "ai", "personas", "cancel",
+        method="POST", body="",
+        params={"chat_path": "notebooks/chat.chat"},
+    )
+
+    assert response.code == 200
+    body = json.loads(response.body)
+    assert body["cancelled"] == [busy.id]
+    idle.cancel_response.assert_not_awaited()
+    busy.cancel_response.assert_awaited_once()
 
 
 async def test_cancel_handler_requires_chat_path(jp_fetch):


### PR DESCRIPTION
## Motivation

We're moving the chat input toolbar UI (persona picker, model/settings controls, usage chip, slash commands) out of jupyter-ai-acp-client and into this package, since it now depends only on the awareness channel and message metadata — both owned here. The one toolbar item that was still backend-specific is the stop button: today it lives in acp-client and calls an ACP-only REST route to cancel an agent turn.

To let the stop button live in the shared toolbar here, personas need a backend-agnostic way to be interrupted. Otherwise every persona backend has to wire its own stop path, and the toolbar can't own the button.

## Summary

Adds an async `cancel_response()` method to `BasePersona` — the counterpart to `process_message`. When a user interrupts a persona from the chat UI, this halts whatever the reply set in motion (a model stream, an agent turn, pending tool calls) so the persona stops writing promptly.

It's optional: the default is a no-op, for personas that have nothing cancellable or reply synchronously. A streaming or long-running persona (e.g. an ACP agent) overrides it to interrupt its own backend. A generic stop button can then call one method regardless of the persona behind it.

No UI wiring is included here — this is just the base-class hook. The toolbar and a persona-manager stop route that calls `cancel_response()` will follow in the UI-migration PR.

## Testing

Unit tests cover the no-op default and that a subclass override is invoked.