### PR TITLE
Let extensions contribute controls to the persona controls toolbar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,10 @@ import {
 
 import { PersonaControls } from './persona-controls';
 import {
+  IPersonaControlRegistry,
+  PersonaControlRegistry
+} from './persona-control-registry';
+import {
   SLASH_COMMAND_PROVIDER_ID,
   SlashCommandProvider
 } from './slash-commands';
@@ -19,6 +23,9 @@ import { StopButton } from './stop-button';
 // Public awareness API: typed, read-only views of the persona-manager and
 // persona awareness slots, for consumers building on the awareness channel.
 export * from './awareness';
+
+// Public API for contributing controls to the persona controls toolbar.
+export * from './persona-control-registry';
 
 /**
  * Initialization data for the @jupyter-ai/persona-manager extension.
@@ -49,6 +56,22 @@ const slashCommandPlugin: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * Plugin that provides the persona control registry, the extension point other
+ * extensions use to contribute controls (e.g. a persona's settings button) to
+ * the persona controls in the chat input toolbar.
+ */
+const controlRegistryPlugin: JupyterFrontEndPlugin<IPersonaControlRegistry> = {
+  id: '@jupyter-ai/persona-manager:control-registry',
+  description:
+    'Provides the registry for contributing controls to the persona controls toolbar.',
+  autoStart: true,
+  provides: IPersonaControlRegistry,
+  activate: (): IPersonaControlRegistry => {
+    return new PersonaControlRegistry();
+  }
+};
+
+/**
  * Plugin that provides the chat input toolbar factory: the default toolbar
  * plus the persona controls (picker, model, settings, usage) and a stop
  * button. The chat panel picks this up and uses it to build the toolbar for
@@ -59,14 +82,24 @@ const toolbarPlugin: JupyterFrontEndPlugin<IInputToolbarRegistryFactory> = {
   description: 'Provides the chat input toolbar with persona controls.',
   autoStart: true,
   provides: IInputToolbarRegistryFactory,
-  activate: (): IInputToolbarRegistryFactory => {
+  requires: [IPersonaControlRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    controlRegistry: IPersonaControlRegistry
+  ): IInputToolbarRegistryFactory => {
+    // Wrap the persona controls to inject the control registry, which the
+    // generic toolbar-item props don't carry. Contributed controls (e.g. a
+    // persona's settings button) render for the selected persona.
+    const PersonaControlsItem = (
+      itemProps: InputToolbarRegistry.IToolbarItemProps
+    ) => PersonaControls({ ...itemProps, controlRegistry });
     return {
       create: () => {
         // Start with the default toolbar (Send, Attach, Cancel, SaveEdit)
         const registry = InputToolbarRegistry.defaultToolbarRegistry();
         // Add the active-persona controls (persona + model), leftmost.
         registry.addItem('persona', {
-          element: PersonaControls,
+          element: PersonaControlsItem,
           position: 5
         });
         // Stop button, between the persona controls (5) and the default
@@ -82,4 +115,9 @@ const toolbarPlugin: JupyterFrontEndPlugin<IInputToolbarRegistryFactory> = {
   }
 };
 
-export default [plugin, slashCommandPlugin, toolbarPlugin];
+export default [
+  plugin,
+  slashCommandPlugin,
+  controlRegistryPlugin,
+  toolbarPlugin
+];

--- a/src/persona-control-registry.ts
+++ b/src/persona-control-registry.ts
@@ -1,0 +1,89 @@
+import { Token } from '@lumino/coreutils';
+import { IChatModel, IInputModel } from '@jupyter/chat';
+import * as React from 'react';
+
+/**
+ * Props passed to a contributed persona control. They give the control the
+ * context it needs to act: which persona is selected, and the chat and input
+ * models of the toolbar it is rendered in.
+ */
+export interface IPersonaControlProps {
+  /** The ID of the persona currently selected in the persona picker. */
+  personaId: string;
+  /** The chat model, for reading chat state / awareness. */
+  chatModel?: IChatModel;
+  /** The input model, for reading or stamping message metadata. */
+  model: IInputModel;
+}
+
+/**
+ * A control contributed to the persona controls in the chat input toolbar.
+ *
+ * This is the extension point that lets a persona's frontend plugin add its own
+ * control (e.g. a settings button) next to the built-in persona picker, model
+ * selector, and usage chip — without the persona-manager hard-coding anything
+ * persona-specific.
+ */
+export interface IPersonaControl {
+  /** A unique ID for this control (used as the React key and for dedup). */
+  id: string;
+  /**
+   * The React component rendered for this control. It receives
+   * `IPersonaControlProps`.
+   */
+  component: React.FunctionComponent<IPersonaControlProps>;
+  /**
+   * The ID of the persona this control belongs to. The control is only rendered
+   * when that persona is selected. Omit to render the control for every persona.
+   */
+  personaId?: string;
+  /**
+   * Sort order among contributed controls (ascending). Controls with the same
+   * rank keep registration order. Defaults to 0.
+   */
+  rank?: number;
+}
+
+/**
+ * A registry of controls contributed to the persona controls toolbar. Extensions
+ * obtain it via the `IPersonaControlRegistry` token and call `addControl` to add
+ * their own controls; the persona controls render the ones that apply to the
+ * selected persona.
+ */
+export interface IPersonaControlRegistry {
+  /** Register a control. */
+  addControl(control: IPersonaControl): void;
+  /**
+   * Return the controls to render for the given selected persona, in rank order:
+   * controls scoped to that persona plus controls scoped to all personas.
+   */
+  getControls(personaId: string): IPersonaControl[];
+}
+
+/**
+ * The token used to require/provide the persona control registry.
+ */
+export const IPersonaControlRegistry = new Token<IPersonaControlRegistry>(
+  '@jupyter-ai/persona-manager:IPersonaControlRegistry',
+  'A registry for contributing controls to the persona controls in the chat input toolbar.'
+);
+
+/**
+ * Default `IPersonaControlRegistry` implementation.
+ */
+export class PersonaControlRegistry implements IPersonaControlRegistry {
+  private _controls: IPersonaControl[] = [];
+
+  addControl(control: IPersonaControl): void {
+    // Replace any existing control with the same ID so re-registration (e.g. on
+    // a plugin reload) doesn't duplicate it.
+    this._controls = this._controls.filter(c => c.id !== control.id);
+    this._controls.push(control);
+  }
+
+  getControls(personaId: string): IPersonaControl[] {
+    return this._controls
+      .filter(c => c.personaId === undefined || c.personaId === personaId)
+      .sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+  }
+}

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -31,6 +31,7 @@ import {
   buildMessageMetadata,
   emptyPersonaSettings
 } from './metadata';
+import { IPersonaControlRegistry } from './persona-control-registry';
 
 const SELECTOR_CLASS = 'jp-jai-personaControls';
 const MENU_CLASS = 'jp-jai-controlMenu';
@@ -791,9 +792,16 @@ export function UsageChip(props: { usage: Usage }): JSX.Element | null {
  * polling). It's seeded from the default persona advertised over PageConfig.
  */
 export function PersonaControls(
-  props: InputToolbarRegistry.IToolbarItemProps
+  props: InputToolbarRegistry.IToolbarItemProps & {
+    /**
+     * Registry of controls contributed by other extensions (e.g. a persona's
+     * settings button). Rendered for the selected persona after the usage chip.
+     * Optional so the component still works without a registry.
+     */
+    controlRegistry?: IPersonaControlRegistry;
+  }
 ): JSX.Element | null {
-  const { chatModel, model } = props;
+  const { chatModel, model, controlRegistry } = props;
   const awareness = chatModel?.awareness ?? null;
 
   // The manager's awareness view, resolved once its slot appears. Null until
@@ -995,6 +1003,21 @@ export function PersonaControls(
       </Menu>
 
       <UsageChip usage={usage} />
+
+      {/* Controls contributed by other extensions for the selected persona
+          (e.g. a persona's settings button). */}
+      {selectedId &&
+        controlRegistry?.getControls(selectedId).map(control => {
+          const Control = control.component;
+          return (
+            <Control
+              key={control.id}
+              personaId={selectedId}
+              chatModel={chatModel}
+              model={model}
+            />
+          );
+        })}
 
       {controls.length ? (
         <>

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -1004,8 +1004,16 @@ export function PersonaControls(
 
       <UsageChip usage={usage} />
 
+      {controls.length ? (
+        <>
+          <span className={`${SELECTOR_CLASS}-divider`} />
+          <ControlsRow controls={controls} onChange={handleControl} />
+        </>
+      ) : null}
+
       {/* Controls contributed by other extensions for the selected persona
-          (e.g. a persona's settings button). */}
+          (e.g. a persona's settings button), rendered after the model selector
+          and its settings so they sit to the right of them. */}
       {selectedId &&
         controlRegistry?.getControls(selectedId).map(control => {
           const Control = control.component;
@@ -1018,13 +1026,6 @@ export function PersonaControls(
             />
           );
         })}
-
-      {controls.length ? (
-        <>
-          <span className={`${SELECTOR_CLASS}-divider`} />
-          <ControlsRow controls={controls} onChange={handleControl} />
-        </>
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Motivation

The persona controls in the chat input toolbar (persona picker, model selector, usage chip) are select-only. Some personas need a control that a dropdown can't express — Jupyternaut, for instance, needs a button that opens its own settings view for precise per-field model configuration. Until now the only way to add such a control was to hard-code it into the shared persona controls, which doesn't scale and couples persona-manager to specific personas.

## Summary

Adds `IPersonaControlRegistry`, a token other extensions require to contribute a control to the persona controls. A contributed control is a React component plus the ID of the persona it belongs to; the persona controls render the controls that apply to the currently-selected persona, next to the built-in ones. A control with no persona ID renders for every persona.

Nothing persona-specific is baked into persona-manager: a persona's own frontend plugin registers its control.

## Technical details

The toolbar factory injects the registry into the persona controls (the generic toolbar-item props don't carry it). Contributed controls render after the usage chip and receive the selected persona ID plus the chat and input models.

First consumer: jupyter-ai-contrib/jupyter-ai-jupyternaut#70 registers Jupyternaut's settings button through this.