### PR TITLE
[WIP] Virtualize large menus with CSS containment

### DIFF
--- a/src/__tests__/persona-controls.spec.ts
+++ b/src/__tests__/persona-controls.spec.ts
@@ -6,7 +6,12 @@
 
 import { PersonaOption } from '../awareness';
 
-import { buildControls, reconcileSelection } from '../persona-controls';
+import {
+  buildControls,
+  reconcileSelection,
+  shouldVirtualizeOptions,
+  VIRTUALIZE_OPTION_THRESHOLD
+} from '../persona-controls';
 import { emptyPersonaSettings, PersonaSettings } from '../metadata';
 import { personaAwareness } from './awareness-fixture';
 
@@ -149,5 +154,18 @@ describe('reconcileSelection', () => {
 
   it('makes no decision before personas load', () => {
     expect(reconcileSelection([], 'a', false)).toBeUndefined();
+  });
+});
+
+describe('shouldVirtualizeOptions', () => {
+  it('does not virtualize small option lists', () => {
+    expect(shouldVirtualizeOptions(0)).toBe(false);
+    expect(shouldVirtualizeOptions(10)).toBe(false);
+    expect(shouldVirtualizeOptions(VIRTUALIZE_OPTION_THRESHOLD)).toBe(false);
+  });
+
+  it('virtualizes lists above the threshold', () => {
+    expect(shouldVirtualizeOptions(VIRTUALIZE_OPTION_THRESHOLD + 1)).toBe(true);
+    expect(shouldVirtualizeOptions(2000)).toBe(true);
   });
 });

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -82,6 +82,22 @@ const menuAnchorProps = {
 };
 
 /**
+ * Anchor props for a control dropdown: the shared menu anchoring, with the
+ * virtualized paper class added when the menu will hold enough options for CSS
+ * containment to pay off (see `shouldVirtualizeOptions`).
+ */
+function menuAnchorPropsFor(optionCount: number) {
+  return shouldVirtualizeOptions(optionCount)
+    ? {
+        ...menuAnchorProps,
+        PaperProps: {
+          className: `${MENU_CLASS}-paper ${MENU_CLASS}-paper-virtualized`
+        }
+      }
+    : menuAnchorProps;
+}
+
+/**
  * A UI control for one control (the model, a model setting, or a general
  * setting). It carries the persona's current value (from awareness) and the
  * user's per-message selection (null = use the persona's default).
@@ -310,15 +326,7 @@ function ControlItem(props: {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   // Large option lists opt into CSS containment on each row (see the
   // `-virtualized` style) so off-screen items are skipped during layout/paint.
-  const virtualize = shouldVirtualizeOptions(control.options.length);
-  const menuAnchorPropsForControl = virtualize
-    ? {
-        ...menuAnchorProps,
-        PaperProps: {
-          className: `${MENU_CLASS}-paper ${MENU_CLASS}-paper-virtualized`
-        }
-      }
-    : menuAnchorProps;
+  const menuAnchorPropsForControl = menuAnchorPropsFor(control.options.length);
   return (
     <>
       <Button
@@ -380,13 +388,13 @@ function OverflowMenu(props: {
   onChange: (control: Control, value: string | null) => void;
 }): JSX.Element {
   const { controls, anchor, onClose, onChange } = props;
+  // The overflow menu renders every overflowed control's options in one list,
+  // so containment is decided by their combined option count.
+  const anchorProps = menuAnchorPropsFor(
+    controls.reduce((n, c) => n + c.options.length, 0)
+  );
   return (
-    <Menu
-      anchorEl={anchor}
-      open={!!anchor}
-      onClose={onClose}
-      {...menuAnchorProps}
-    >
+    <Menu anchorEl={anchor} open={!!anchor} onClose={onClose} {...anchorProps}>
       {controls.flatMap(control => [
         <ListSubheader
           key={`${control.id}-label`}

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -41,6 +41,23 @@ const NO_ONE_LABEL = 'No one';
 // Stable control ID for the model selector (setting IDs are used verbatim).
 const MODEL_CONTROL_ID = '__model__';
 
+// Above this many options, a control's dropdown opts into CSS containment
+// (`content-visibility: auto`) so the browser skips layout/paint for off-screen
+// rows. Some personas advertise very large option lists (e.g. the full LiteLLM
+// model catalog, ~2000 entries), which is otherwise slow to scroll through.
+// Small lists render normally — containment adds no benefit and its intrinsic
+// sizing can cause faint scrollbar jitter, so it's gated behind this threshold.
+export const VIRTUALIZE_OPTION_THRESHOLD = 128;
+
+/**
+ * Whether a control's dropdown should opt into CSS containment for its rows,
+ * based on how many options it has. Only large lists benefit; see
+ * `VIRTUALIZE_OPTION_THRESHOLD`.
+ */
+export function shouldVirtualizeOptions(optionCount: number): boolean {
+  return optionCount > VIRTUALIZE_OPTION_THRESHOLD;
+}
+
 // Context-fill fractions at which the chip starts demanding attention: the
 // ring and percent turn warn, then error, colored.
 const USAGE_WARN_AT = 0.7;
@@ -291,6 +308,17 @@ function ControlItem(props: {
 }): JSX.Element {
   const { control, onSelect } = props;
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  // Large option lists opt into CSS containment on each row (see the
+  // `-virtualized` style) so off-screen items are skipped during layout/paint.
+  const virtualize = shouldVirtualizeOptions(control.options.length);
+  const menuAnchorPropsForControl = virtualize
+    ? {
+        ...menuAnchorProps,
+        PaperProps: {
+          className: `${MENU_CLASS}-paper ${MENU_CLASS}-paper-virtualized`
+        }
+      }
+    : menuAnchorProps;
   return (
     <>
       <Button
@@ -310,7 +338,7 @@ function ControlItem(props: {
         anchorEl={anchor}
         open={!!anchor}
         onClose={() => setAnchor(null)}
-        {...menuAnchorProps}
+        {...menuAnchorPropsForControl}
       >
         <ChoiceMenuItem
           primary={defaultChoiceLabel(control)}

--- a/style/base.css
+++ b/style/base.css
@@ -239,6 +239,20 @@
   font-size: var(--jp-ui-font-size1);
 }
 
+/* Large option lists (see VIRTUALIZE_OPTION_THRESHOLD in persona-controls.tsx)
+   opt into CSS containment: the browser skips layout and paint for rows
+   scrolled out of view, so a list of ~2000 models scrolls smoothly. Every row
+   stays in the DOM, so MUI keyboard navigation, typeahead, and selection are
+   unaffected. `contain-intrinsic-size` supplies an estimated row height for the
+   skipped rows, keeping the scrollbar length stable. The height (~33px) matches
+   a single-line item: 6px+6px padding plus the ~21px line box at the JAI base
+   font size; a two-line description row is a touch taller, which only makes the
+   estimate slightly conservative. */
+.jp-jai-controlMenu-paper-virtualized .MuiMenuItem-root {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 33px;
+}
+
 .jp-jai-controlMenu-paper .MuiMenuItem-root:hover,
 .jp-jai-controlMenu-paper .MuiMenuItem-root.Mui-selected,
 .jp-jai-controlMenu-paper .MuiMenuItem-root.Mui-selected:hover {


### PR DESCRIPTION
## Motivation

A persona can advertise a very large list of models. Jupyternaut, for instance, now offers the full LiteLLM model catalog — around 2000 entries. The model dropdown renders every option as a menu item, so with a list that size the browser lays out and paints ~2000 DOM nodes, and scrolling or arrow-keying through it is noticeably slow.

## Summary

When a control's option list is large, its dropdown now opts into CSS containment (`content-visibility: auto` on each row), so the browser skips layout and paint for rows scrolled out of view. A 2000-model list scrolls smoothly, while every row stays in the DOM — MUI keyboard navigation, typeahead, and selection all keep working. Small lists are unchanged; containment only kicks in above a threshold (128 options), since it adds no benefit for short menus and its intrinsic sizing can cause faint scrollbar jitter.

## Technical details

This avoids a windowing dependency: `content-visibility` is a one-line-per-row CSS opt-in that fixes the scroll/paint cost, which is the part users feel, without breaking MUI Menu's built-in keyboard handling (a JS virtualizer would). `contain-intrinsic-size` supplies an estimated row height so the scrollbar stays stable. The decision is a small pure helper (`shouldVirtualizeOptions`), unit-tested at the boundary.