### PR TITLE
Show a loading placeholder while the persona list resolves

### DIFF
--- a/src/__tests__/persona-controls.spec.ts
+++ b/src/__tests__/persona-controls.spec.ts
@@ -6,7 +6,11 @@
 
 import { PersonaOption } from '../awareness';
 
-import { buildControls, reconcileSelection } from '../persona-controls';
+import {
+  buildControls,
+  reconcileSelection,
+  showLoadingPlaceholder
+} from '../persona-controls';
 import { emptyPersonaSettings, PersonaSettings } from '../metadata';
 import { personaAwareness } from './awareness-fixture';
 
@@ -149,5 +153,27 @@ describe('reconcileSelection', () => {
 
   it('makes no decision before personas load', () => {
     expect(reconcileSelection([], 'a', false)).toBeUndefined();
+  });
+});
+
+describe('showLoadingPlaceholder', () => {
+  it('shows while the manager is still resolving', () => {
+    expect(showLoadingPlaceholder(true, false, false, false)).toBe(true);
+  });
+
+  it('shows until the first persona-list read lands', () => {
+    expect(showLoadingPlaceholder(true, true, false, false)).toBe(true);
+  });
+
+  it('hides once the list has been read (an empty chat is empty, not loading)', () => {
+    expect(showLoadingPlaceholder(true, true, false, true)).toBe(false);
+  });
+
+  it('hides when resolution failed', () => {
+    expect(showLoadingPlaceholder(true, false, true, false)).toBe(false);
+  });
+
+  it('hides without an awareness channel to wait on', () => {
+    expect(showLoadingPlaceholder(false, false, false, false)).toBe(false);
   });
 });

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -182,6 +182,25 @@ export function reconcileSelection(
 }
 
 /**
+ * Whether the toolbar, knowing no personas yet, should show the loading
+ * placeholder rather than nothing: only while the manager's slot can still
+ * resolve (awareness exists, resolution hasn't failed) and the manager or its
+ * first persona-list read is still pending. Without an awareness channel there
+ * is nothing to wait on, so nothing renders.
+ */
+export function showLoadingPlaceholder(
+  hasAwareness: boolean,
+  managerResolved: boolean,
+  managerFailed: boolean,
+  listRead: boolean
+): boolean {
+  if (!hasAwareness || managerFailed) {
+    return false;
+  }
+  return !managerResolved || !listRead;
+}
+
+/**
  * Fold a changed control value into the user's `PersonaSettings`, keyed by the
  * control's kind. A null value resets that control to the persona's default.
  */
@@ -951,7 +970,14 @@ export function PersonaControls(
   // pending, show a loading placeholder (on slow networks this takes seconds);
   // once resolution failed or the chat genuinely has no personas, show nothing.
   if (!personas.length) {
-    if (!managerFailed && (!manager || !listRead)) {
+    if (
+      showLoadingPlaceholder(
+        awareness !== null,
+        manager !== null,
+        managerFailed,
+        listRead
+      )
+    ) {
       return <LoadingPlaceholder />;
     }
     return null;

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -11,7 +11,8 @@ import {
   ListSubheader,
   Menu,
   MenuItem,
-  Popover
+  Popover,
+  Skeleton
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import CheckIcon from '@mui/icons-material/Check';
@@ -220,6 +221,23 @@ function Avatar(props: { url: string | null | undefined }): JSX.Element {
     return <span className={`${SELECTOR_CLASS}-avatar-spacer`} />;
   }
   return <img className={`${SELECTOR_CLASS}-avatar`} src={props.url} alt="" />;
+}
+
+/**
+ * Placeholder for the toolbar while the persona list is being resolved over
+ * awareness: a circle where the picker's avatar sits and a bar where its label
+ * sits, so a slow network reads as loading rather than a missing toolbar.
+ */
+function LoadingPlaceholder(): JSX.Element {
+  return (
+    <div
+      className={`${SELECTOR_CLASS}-group ${SELECTOR_CLASS}-skeleton`}
+      title="Loading personas"
+    >
+      <Skeleton variant="circular" width={18} height={18} />
+      <Skeleton variant="rounded" width={90} height={12} />
+    </div>
+  );
 }
 
 /**
@@ -808,6 +826,13 @@ export function PersonaControls(
   // then. `PersonaManagerAwareness.from()` polls internally, so nothing here
   // polls; once resolved, awareness `change` events drive all updates.
   const [manager, setManager] = useState<PersonaManagerAwareness | null>(null);
+  // Whether resolving the manager's slot failed (timed out, extension absent).
+  // Hides the loading placeholder along with the toolbar.
+  const [managerFailed, setManagerFailed] = useState(false);
+  // Whether the first persona-list read has completed after the manager
+  // resolved. Before that, an empty list means "still loading", not "this chat
+  // has no personas".
+  const [listRead, setListRead] = useState(false);
   const [personas, setPersonas] = useState<PersonaOption[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(
     DEFAULT_PERSONA_ID
@@ -849,6 +874,9 @@ export function PersonaControls(
         // Manager never registered (e.g. extension disabled); the toolbar
         // stays hidden. Surface why, or the empty toolbar is undiagnosable.
         console.warn('Persona toolbar hidden:', reason);
+        if (!cancelled) {
+          setManagerFailed(true);
+        }
       });
     return () => {
       cancelled = true;
@@ -876,6 +904,7 @@ export function PersonaControls(
       return;
     }
     readManager();
+    setListRead(true);
     const onChange = () => readManager();
     awareness.on('change', onChange);
     return () => {
@@ -918,8 +947,13 @@ export function PersonaControls(
     model.updateMetadata(buildMessageMetadata(selectedId, settings));
   }, [model, metadataSignature]);
 
-  // No personas in the chat: nothing to show.
+  // No personas yet. While the manager's slot or its first list read is still
+  // pending, show a loading placeholder (on slow networks this takes seconds);
+  // once resolution failed or the chat genuinely has no personas, show nothing.
   if (!personas.length) {
+    if (!managerFailed && (!manager || !listRead)) {
+      return <LoadingPlaceholder />;
+    }
     return null;
   }
 

--- a/style/base.css
+++ b/style/base.css
@@ -420,3 +420,17 @@
 .jp-jai-usage-row-value {
   white-space: nowrap;
 }
+
+/* Loading placeholder shown while the persona list resolves over awareness:
+   sits where the persona button will, matching its footprint (18px avatar,
+   6px gap to the label, the button's padding). */
+.jp-jai-personaControls-skeleton {
+  gap: 6px;
+  padding: 1px 6px;
+}
+
+/* stylelint-disable selector-class-pattern -- theming MUI's skeleton */
+.jp-ThemedContainer .jp-jai-personaControls-skeleton .MuiSkeleton-root {
+  background-color: var(--jp-border-color2);
+}
+/* stylelint-enable selector-class-pattern */


### PR DESCRIPTION
Fixes #73

## Problem

While the chat toolbar waits for the PersonaManager to publish its persona list over awareness, it renders nothing. On slow networks, or servers with heavy persona initialization, this window lasts seconds, and an empty toolbar reads as broken rather than loading.

## Changes

- `src/persona-controls.tsx`: renders a `LoadingPlaceholder` (MUI Skeleton circle plus label bar, matching the persona button's footprint) while `PersonaManagerAwareness.from()` is still resolving or the first persona-list read has not completed. The decision is the exported pure function `showLoadingPlaceholder(hasAwareness, managerResolved, managerFailed, listRead)`: it shows only while awareness exists, resolution has not failed, and the manager or its first list read is pending. Resolution failure (extension absent, 60 second timeout), a chat model without awareness, and a chat with genuinely no personas all render nothing, as before.
- `style/base.css`: skeleton styling through theme tokens (`--jp-border-color2`), sized to the persona button footprint so the swap causes no layout shift.

The error state after a long wait discussed in the issue is left as a follow-up; this covers the short-term loading indicator.

## Testing

- 5 new test cases pinning the placeholder gate (pending shows, first-read pending shows, read-empty hides, failed hides, no awareness hides)
- Verified live in JupyterLab 