### PR TITLE
Document usage fallback semantics and scope the cost estimate label to USD

### DIFF
--- a/jupyter_ai_persona_manager/awareness_models.py
+++ b/jupyter_ai_persona_manager/awareness_models.py
@@ -86,9 +86,11 @@ class Usage(BaseModel):
     # decrease during a session (e.g. after the agent compacts context).
     context_tokens: int | None = None  # tokens currently in the window
     context_size: int | None = None  # total window size
-    # Context fill as a bare percentage (0-100), for agents that report only a
-    # percentage with no token counts (e.g. kiro-cli). Consumers derive the
-    # percentage from `context_tokens`/`context_size` when those are present.
+    # Context fill as a bare percentage (0-100), the fallback for agents that
+    # report only a percentage with no token counts (e.g. kiro-cli). Precedence
+    # contract for consumers: when `context_tokens`/`context_size` are present,
+    # derive the percentage from them and ignore this field; read this field
+    # only when they are absent.
     context_percent: float | None = None
 
     # Cumulative token counts for the session.
@@ -99,9 +101,11 @@ class Usage(BaseModel):
     thought_tokens: int | None = None
     total_tokens: int | None = None
 
-    # Cumulative session cost.
+    # Cumulative session cost. The currency is an ISO 4217 code (e.g. "USD")
+    # or, for agents that meter in their own unit, that unit's plural name
+    # (e.g. "credits").
     cost_amount: float | None = None
-    cost_currency: str | None = None  # ISO 4217, e.g. "USD"
+    cost_currency: str | None = None
 
 
 class CommandOption(BaseModel):

--- a/src/awareness.ts
+++ b/src/awareness.ts
@@ -69,9 +69,10 @@ export type Usage = {
   context_tokens: number | null;
   context_size: number | null;
   /**
-   * Context fill as a bare percentage (0-100), for agents that report only a
-   * percentage with no token counts. Derive the percentage from
-   * `context_tokens`/`context_size` when those are present.
+   * Context fill as a bare percentage (0-100), the fallback for agents that
+   * report only a percentage with no token counts. Precedence contract: when
+   * `context_tokens`/`context_size` are present, derive the percentage from
+   * them and ignore this field; read this field only when they are absent.
    */
   context_percent: number | null;
   input_tokens: number | null;
@@ -81,6 +82,10 @@ export type Usage = {
   thought_tokens: number | null;
   total_tokens: number | null;
   cost_amount: number | null;
+  /**
+   * An ISO 4217 code (e.g. "USD") or, for agents that meter in their own
+   * unit, that unit's plural name (e.g. "credits").
+   */
   cost_currency: string | null;
 };
 

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -551,7 +551,7 @@ export function formatTokensExact(n: number): string {
 }
 
 /**
- * Format a cost amount with its ISO 4217 currency code.
+ * Format a cost amount with its currency code or unit name (e.g. "credits").
  */
 export function formatCost(amount: number, currency: string): string {
   const value = costNumber.format(amount);
@@ -645,7 +645,8 @@ export function UsageChip(props: { usage: Usage }): JSX.Element | null {
 
   const hasContext =
     usage.context_tokens !== null && usage.context_size !== null;
-  // Agents like kiro-cli report context fill only as a bare percentage.
+  // Precedence: a token-derived percentage always wins; `context_percent` is
+  // read only when the agent reported no token counts (e.g. kiro-cli).
   const hasPercentOnly = !hasContext && usage.context_percent !== null;
   const showContext = hasContext || hasPercentOnly;
   const hasTokens = usage.total_tokens !== null;
@@ -765,12 +766,23 @@ export function UsageChip(props: { usage: Usage }): JSX.Element | null {
           ) : null}
           {hasCost ? (
             <UsageSection
-              label="Session cost (est.)"
+              // API list prices are quoted in USD; for any other unit (e.g.
+              // metered credits) the amount is the agent's own accounting, so
+              // neither the estimate suffix nor the list-price note applies.
+              label={
+                usage.cost_currency === 'USD'
+                  ? 'Session cost (est.)'
+                  : 'Session cost'
+              }
               value={formatCost(
                 usage.cost_amount as number,
                 usage.cost_currency as string
               )}
-              title="Estimated at API list prices"
+              title={
+                usage.cost_currency === 'USD'
+                  ? 'Estimated at API list prices'
+                  : undefined
+              }
             />
           ) : null}
         </div>


### PR DESCRIPTION
## Problem

Review feedback on the usage schema: the relationship between `context_percent` and the token fields was implied rather than stated, and `cost_currency` was documented as ISO 4217 only, while agents that meter usage (kiro-cli) report their own unit ("credits"). The popover's cost section also labels every amount "Session cost (est.)" with an "Estimated at API list prices" hover, which is wrong for metered units: those are the agent's own accounting, not an estimate.

## Changes

- `jupyter_ai_persona_manager/awareness_models.py` and `src/awareness.ts`: `context_percent` now states the precedence contract (consumers derive the percentage from `context_tokens`/`context_size` when present and read this field only when they are absent), and `cost_currency` is documented as an ISO 4217 code or the agent's own unit name (e.g. "credits").
- `src/persona-controls.tsx`: a comment at the chip's fallback branch names the precedence; the "(est.)" label suffix and the list-prices hover render only for USD, since API list prices are quoted in USD; `formatCost`'s docstring matches.