### PR TITLE
Fix selected notebook attachment processing

### DIFF
--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import html
+import json
 import os
 import traceback
 from abc import ABC, ABCMeta, abstractmethod
@@ -716,8 +717,36 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
                 # Get relative path for display
                 rel_path = os.path.relpath(file_path, self.get_workspace_dir())
 
-                # Add file content with header
-                context_parts.append(f"File: {rel_path}\n```\n{file_content}\n```")
+                attachment_data = self.ychat.get_attachments().get(attachment_id)
+                if (
+                    isinstance(attachment_data, dict)
+                    and attachment_data.get("type") == "notebook"
+                    and attachment_data.get("cells")
+                ):
+                    notebook = json.loads(file_content)
+                    cells_by_id = {
+                        cell.get("id"): cell for cell in notebook.get("cells", [])
+                    }
+                    selected_cells = []
+                    for requested in attachment_data["cells"]:
+                        cell = cells_by_id.get(requested.get("id"))
+                        if cell is None:
+                            continue
+                        source = cell.get("source", "")
+                        if isinstance(source, list):
+                            source = "".join(source)
+                        cell_type = cell.get(
+                            "cell_type", requested.get("input_type", "")
+                        )
+                        selected_cells.append(
+                            f"Cell: {cell.get('id')} ({cell_type})\n```\n{source}\n```"
+                        )
+                    context_parts.append(
+                        f"Notebook: {rel_path}\n" + "\n\n".join(selected_cells)
+                    )
+                else:
+                    # Add file content with header
+                    context_parts.append(f"File: {rel_path}\n```\n{file_content}\n```")
 
             except Exception as e:
                 self.log.warning(f"Failed to read attachment {attachment_id}: {e}")

--- a/jupyter_ai_persona_manager/tests/test_base_persona.py
+++ b/jupyter_ai_persona_manager/tests/test_base_persona.py
@@ -1,5 +1,6 @@
 """Tests for BasePersona.handle_uncaught_exception() and stream_message() re-raise."""
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -46,6 +47,44 @@ def _make_persona(mock_ychat):
     persona.awareness = MagicMock()
     persona._processing_count = 0
     return persona
+
+
+def test_process_attachments_limits_notebook_to_selected_cells(mock_ychat, tmp_path):
+    notebook = tmp_path / "example.ipynb"
+    notebook.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "id": "wanted",
+                        "source": ["print('wanted')\n"],
+                    },
+                    {
+                        "cell_type": "markdown",
+                        "id": "omitted",
+                        "source": ["SECRET OMITTED CELL\n"],
+                    },
+                ]
+            }
+        )
+    )
+    mock_ychat.get_attachments.return_value = {
+        "attachment-1": {
+            "type": "notebook",
+            "value": "example.ipynb",
+            "cells": [{"id": "wanted", "input_type": "code"}],
+        }
+    }
+    persona = _make_persona(mock_ychat)
+    persona.get_workspace_dir = lambda: str(tmp_path)
+    message = MagicMock(attachments=["attachment-1"])
+
+    result = persona.process_attachments(message)
+
+    assert result is not None
+    assert "print('wanted')" in result
+    assert "SECRET OMITTED CELL" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #36.

Notebook attachments now parse the `.ipynb` document and include only the cells selected by the user, while whole-file notebook attachments retain their existing behavior. The regression test fails against the previous implementation and passes with the fix; focused Ruff checks and compilation also pass.
