### PR TITLE
Add restart() to restart a single persona

### DIFF
--- a/docs/source/contributors/architecture.md
+++ b/docs/source/contributors/architecture.md
@@ -19,6 +19,10 @@ chat's room** (`text:chat:<file-id>`). That manager:
 
 `/refresh-personas` tears the instances down and rebuilds them (picking up code
 changes and new local personas) without restarting the server.
+{py:meth}`~jupyter_ai_persona_manager.BasePersona.restart` is the single-persona
+counterpart: it shuts one persona down and reconstructs the same class under the
+same ID, leaving the other personas in the chat untouched. It backs the
+`/restart` command routed to a persona via `metadata["to_persona"]`.
 
 ## Selecting a persona: message metadata, not `@`-mentions
 

--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -757,6 +757,27 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
             self.log.error(f"Failed to resolve attachment {attachment_id}: {e}")
             return None
 
+    @mark_consumer_api
+    async def restart(self) -> bool:
+        """
+        Restart this persona: shut its current instance down and reconstruct it
+        under the same ID, leaving other personas in the chat untouched.
+
+        This is the single-persona counterpart to
+        `PersonaManager.refresh_personas()`. It is provided for *consumers* to
+        call — `jupyter_ai_chat_commands` invokes it when the `/restart` slash
+        command is routed to this persona. The default implementation delegates
+        to `PersonaManager.restart_persona()`, which owns the persona-class
+        registry needed to reconstruct the instance.
+
+        Returns `True` if the persona was restarted, `False` otherwise.
+
+        NOTE: after this returns, `self` refers to the *old* instance; the manager
+        has replaced it with a fresh one under the same ID. Callers should not
+        continue to use the persona object they called `restart()` on.
+        """
+        return await self.parent.restart_persona(self.id)
+
     @mark_recommended
     async def shutdown(self) -> None:
         """

--- a/jupyter_ai_persona_manager/persona_manager.py
+++ b/jupyter_ai_persona_manager/persona_manager.py
@@ -509,6 +509,88 @@ class PersonaManager(LoggingConfigurable):
         self.send_system_message("Refreshed all AI personas in this chat.")
         self.log.info(f"Refreshed all AI personas in chat '{self.room_id}'.")
 
+    async def restart_persona(self, persona_id: str) -> bool:
+        """
+        Restart a single persona: shut its current instance down and reconstruct
+        it under the same ID, leaving every other persona in the chat untouched.
+
+        This is the single-persona counterpart to `refresh_personas()`. It is
+        public because it is called by `jupyter_ai_chat_commands` when the
+        `/restart` slash command is routed to a persona (via
+        `BasePersona.restart()`). It reconstructs the *same* class that is
+        currently installed — it does not reload persona code from disk the way
+        `refresh_personas()` does — so it brings a persona back up in a clean
+        state without disturbing its siblings.
+
+        Returns `True` if a persona with `persona_id` was found and restarted,
+        `False` otherwise. Note that on restart the persona's Yjs client ID
+        changes (a fresh awareness slot), so the persona list is republished for
+        the browser to reconcile.
+        """
+        persona = self._personas.get(persona_id)
+        if persona is None:
+            self.log.warning(
+                f"Cannot restart persona '{persona_id}' in chat '{self.room_id}': "
+                "no such persona is installed."
+            )
+            return False
+
+        # Reconstruct the same class that is currently running.
+        PersonaClass = type(persona)
+
+        # Free all transaction locks on the YDoc by awaiting the YChat
+        # background tasks first, mirroring `shutdown_personas()`. Without this,
+        # shutting the persona down while a transaction is in flight can raise a
+        # runtime error.
+        while self.ychat._background_tasks:
+            task = next(iter(self.ychat._background_tasks))
+            await task
+            self.ychat._background_tasks.discard(task)
+
+        # Shut the current instance down (frees its awareness slot & tasks).
+        await persona.shutdown()
+
+        # Reconstruct the persona under the same ID. The new instance registers a
+        # fresh awareness slot and re-adds itself as a chat user in its __init__.
+        try:
+            new_persona = PersonaClass(parent=self, ychat=self.ychat)
+        except Exception:
+            tb_str = traceback.format_exc()
+            self.log.exception(
+                f"Persona '{persona_id}' raised an exception while restarting, "
+                f"printed below.\n{tb_str}"
+            )
+            # The persona is now gone from the chat; drop it and republish so the
+            # UI reflects reality rather than a persona that failed to come back.
+            self._personas.pop(persona_id, None)
+            self._publish_persona_list()
+            self._display_persona_error_message(
+                {
+                    "module": PersonaClass.__module__,
+                    "persona_class": PersonaClass,
+                    "traceback": tb_str,
+                }
+            )
+            return False
+
+        self._personas[persona_id] = new_persona
+
+        # Republish the persona list, since the reloaded persona has a new client
+        # ID, and rebuild the avatar cache across all rooms.
+        self._publish_persona_list()
+        try:
+            persona_managers = self.parent.serverapp.web_app.settings.get(
+                "jupyter-ai", {}
+            ).get("persona-managers", {})
+            build_avatar_cache(persona_managers)
+        except Exception as e:
+            self.log.error(f"Error rebuilding avatar cache: {e}")
+
+        self.log.info(
+            f"Restarted persona '{persona_id}' in chat '{self.room_id}'."
+        )
+        return True
+
     def get_chat_path(self, relative: bool = False) -> str:
         """
         Returns the absolute path of the chat file assigned to this

--- a/jupyter_ai_persona_manager/tests/test_base_persona.py
+++ b/jupyter_ai_persona_manager/tests/test_base_persona.py
@@ -1,6 +1,6 @@
 """Tests for BasePersona.handle_uncaught_exception() and stream_message() re-raise."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -198,6 +198,38 @@ class TestCancelResponse:
         await persona.cancel_response()
 
         assert cancelled is True
+
+
+# ---------------------------------------------------------------------------
+# TestRestart
+# ---------------------------------------------------------------------------
+
+class TestRestart:
+    """`BasePersona.restart()` delegates to `PersonaManager.restart_persona()`
+    with this persona's own ID; it owns the class registry to reconstruct it."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_manager_with_own_id(self, mock_ychat):
+        persona = _make_persona(mock_ychat)
+        parent = MagicMock()
+        parent.restart_persona = AsyncMock(return_value=True)
+        # `parent` is a validated traitlets Instance trait, so bypass validation
+        # by writing the mock into the trait value store directly.
+        persona._trait_values["parent"] = parent
+
+        result = await persona.restart()
+
+        parent.restart_persona.assert_awaited_once_with(persona.id)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_propagates_manager_return_value(self, mock_ychat):
+        persona = _make_persona(mock_ychat)
+        parent = MagicMock()
+        parent.restart_persona = AsyncMock(return_value=False)
+        persona._trait_values["parent"] = parent
+
+        assert await persona.restart() is False
 
 
 # ---------------------------------------------------------------------------

--- a/jupyter_ai_persona_manager/tests/test_persona_manager.py
+++ b/jupyter_ai_persona_manager/tests/test_persona_manager.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from jupyterlab_chat.models import Message
-from jupyter_ai_persona_manager.base_persona import BasePersona
+from jupyter_ai_persona_manager.base_persona import BasePersona, PersonaDefaults
 from jupyter_ai_persona_manager.persona_manager import (
     SYSTEM_USERNAME,
     PersonaManager,
@@ -281,3 +281,133 @@ class TestOnChatMessageRouting:
         for sender in (PERSONA_SENDER, SYSTEM_USERNAME):
             routed = self._route(pm, _message(sender, {"to_persona": "p1"}))
             assert routed == [target]
+
+
+# ---------------------------------------------------------------------------
+# TestRestartPersona
+# ---------------------------------------------------------------------------
+
+def _restart_manager(personas):
+    """A PersonaManager with only the state `restart_persona` touches.
+
+    Bypasses the heavy `__init__`; wires an empty YChat background-task set,
+    stubs the republish + avatar-cache side effects, and provides the
+    `parent.serverapp` chain the cache rebuild reads.
+    """
+    pm = PersonaManager.__new__(PersonaManager)
+    pm._personas = personas
+    pm.log = logging.getLogger("test-persona-manager")
+    pm.room_id = "room"
+    pm.ychat = MagicMock()
+    pm.ychat._background_tasks = set()
+    pm._publish_persona_list = Mock()
+    pm._display_persona_error_message = Mock()
+    # `parent` is a validated traitlets Instance trait; write the mock into the
+    # trait value store directly to bypass validation.
+    parent = MagicMock()
+    parent.serverapp.web_app.settings.get.return_value = {"persona-managers": {}}
+    pm._trait_values["parent"] = parent
+    return pm
+
+
+class _RestartableStub(BasePersona):
+    """Concrete persona whose reconstruction is observable in tests."""
+
+    instances: list = []
+
+    def __init__(self, *args, **kwargs):
+        # Bypass BasePersona.__init__ (needs a real YChat/awareness); just record
+        # the construction so a test can assert reconstruction happened.
+        _RestartableStub.instances.append(self)
+        self.shutdown = AsyncMock()
+
+    @property
+    def defaults(self):
+        return PersonaDefaults(
+            name="Restartable",
+            description="",
+            avatar_path="",
+            system_prompt="",
+        )
+
+    async def process_message(self, message):
+        pass
+
+
+class TestRestartPersona:
+
+    def setup_method(self):
+        _RestartableStub.instances = []
+
+    def _make_persona(self):
+        p = _RestartableStub.__new__(_RestartableStub)
+        p.shutdown = AsyncMock()
+        return p
+
+    @pytest.mark.asyncio
+    async def test_unknown_persona_returns_false(self):
+        pm = _restart_manager(personas={})
+        assert await pm.restart_persona("nope") is False
+
+    @pytest.mark.asyncio
+    async def test_shuts_down_old_and_reconstructs_under_same_id(self):
+        old = self._make_persona()
+        pm = _restart_manager(personas={"pid": old})
+
+        result = await pm.restart_persona("pid")
+
+        assert result is True
+        old.shutdown.assert_awaited_once()
+        # A fresh instance replaced the old one under the same key.
+        assert pm._personas["pid"] is not old
+        assert pm._personas["pid"] is _RestartableStub.instances[-1]
+
+    @pytest.mark.asyncio
+    async def test_republishes_persona_list(self):
+        old = self._make_persona()
+        pm = _restart_manager(personas={"pid": old})
+
+        await pm.restart_persona("pid")
+
+        pm._publish_persona_list.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_drains_background_tasks_before_shutdown(self):
+        old = self._make_persona()
+        pm = _restart_manager(personas={"pid": old})
+        done = AsyncMock()
+        pm.ychat._background_tasks = {done()}
+
+        await pm.restart_persona("pid")
+
+        # The task set is drained (mirrors shutdown_personas), so no transaction
+        # lock survives into the reconstruction.
+        assert pm.ychat._background_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_reconstruction_failure_drops_persona_and_returns_false(self):
+        old = self._make_persona()
+        pm = _restart_manager(personas={"pid": old})
+
+        with patch.object(
+            _RestartableStub, "__init__", side_effect=RuntimeError("boom")
+        ):
+            result = await pm.restart_persona("pid")
+
+        assert result is False
+        # The persona could not come back up, so it is removed from the chat and
+        # the list is republished to reflect that.
+        assert "pid" not in pm._personas
+        pm._publish_persona_list.assert_called_once()
+        pm._display_persona_error_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_other_personas_untouched(self):
+        old = self._make_persona()
+        sibling = _make_mock_persona()
+        pm = _restart_manager(personas={"pid": old, "other": sibling})
+
+        await pm.restart_persona("pid")
+
+        assert pm._personas["other"] is sibling
+        sibling.shutdown.assert_not_called()

--- a/ui-tests/fixtures/personas/lifecycle_persona.py
+++ b/ui-tests/fixtures/personas/lifecycle_persona.py
@@ -1,0 +1,81 @@
+"""
+Shared fixture persona for the `/restart` E2E tests, used by BOTH
+jupyter-ai-persona-manager and jupyter-ai-chat-commands.
+
+It makes a persona's lifecycle observable in the chat: it posts a **start**
+message every time it is constructed and a **stop** message every time it is
+shut down. A restart tears one instance down and builds a fresh one under the
+same ID, so a restart shows up in the chat as a stop message followed by a new
+start message — which is exactly what both suites assert.
+
+Two ways to trigger a restart, one per suite:
+
+- **persona-manager** drives the API directly: send this persona a message whose
+  body is exactly ``restart`` and its ``process_message`` calls
+  ``self.restart()`` (the public `BasePersona` method behind `/restart`). The
+  restart runs in a detached task so it survives this instance's own shutdown.
+- **chat-commands** drives the command path: send ``/restart`` routed to this
+  persona; the chat-commands server extension reads ``metadata['to_persona']``
+  and calls ``PersonaManager.restart_persona()`` on it. This fixture needs no
+  special handling for that path — the stop/start messages fall out of the
+  lifecycle hooks.
+
+Keep this file identical in both repos' ``ui-tests/fixtures/personas/`` (each
+suite installs its own copy at runtime — see AGENTS.md). Not part of either
+shipped package. The avatar is the shared asset located via
+``JAI_TEST_ASSETS_DIR``, exported by the server config.
+"""
+
+import asyncio
+import os
+
+from jupyter_ai_persona_manager import BasePersona, PersonaDefaults
+from jupyterlab_chat.models import Message
+
+_AVATAR_PATH = os.path.join(os.environ["JAI_TEST_ASSETS_DIR"], "persona.svg")
+
+# Stable markers the specs assert on. Kept plain-ASCII and distinct so a spec can
+# match them with a substring check without tripping over each other.
+START_MARKER = "lifecycle:started"
+STOP_MARKER = "lifecycle:stopped"
+
+
+class LifecyclePersona(BasePersona):
+    """Test-only persona that announces its own start and stop in the chat."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Announce startup. Guarded so a hiccup posting the message never breaks
+        # persona loading (which would fail the whole suite).
+        try:
+            self.send_message(START_MARKER)
+        except Exception:
+            self.log.exception("LifecyclePersona failed to post its start message.")
+
+    @property
+    def defaults(self) -> PersonaDefaults:
+        return PersonaDefaults(
+            name="Lifecycle Persona",
+            description="Test-only persona that announces start and stop.",
+            avatar_path=_AVATAR_PATH,
+            system_prompt="unused",
+        )
+
+    async def process_message(self, message: Message) -> None:
+        # The persona-manager suite triggers a restart via the API by sending the
+        # literal message "restart". Run it detached so it outlives this
+        # instance's shutdown (restart() shuts `self` down and replaces it).
+        if message.body.strip() == "restart":
+            asyncio.create_task(self.restart())
+            return
+        # Any other message just gets an acknowledgement, so a plain reply path
+        # still works if a spec needs it.
+        self.send_message("ack")
+
+    async def shutdown(self) -> None:
+        # Announce shutdown before tearing the awareness slot down.
+        try:
+            self.send_message(STOP_MARKER)
+        except Exception:
+            self.log.exception("LifecyclePersona failed to post its stop message.")
+        await super().shutdown()

--- a/ui-tests/tests/restart.spec.ts
+++ b/ui-tests/tests/restart.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, test } from '@jupyterlab/galata';
+import { FixturePersona, installPersonas, TestHelpers } from './test-helpers';
+
+// This suite's working directory and the fixture persona installed into it.
+const TEST_DIR = 'restart';
+const PERSONAS = [FixturePersona.Lifecycle];
+
+// Markers the Lifecycle fixture posts on start and stop (kept in sync with
+// fixtures/personas/lifecycle_persona.py).
+const START_MARKER = 'lifecycle:started';
+const STOP_MARKER = 'lifecycle:stopped';
+
+/**
+ * Exercises `BasePersona.restart()` (the API behind `/restart`) directly, from
+ * inside the persona: the Lifecycle fixture posts a start message when it is
+ * constructed and a stop message when it shuts down, and calls `self.restart()`
+ * when it receives a message whose body is exactly "restart".
+ *
+ * A restart tears one instance down and reconstructs a fresh one under the same
+ * ID, so in the chat it must show up as: the original start, then a stop, then a
+ * brand-new start — proving the persona went down and came back up. The sibling
+ * suite in jupyter-ai-chat-commands asserts the same markers via the `/restart`
+ * command path.
+ */
+test.describe('restart', () => {
+  test.beforeAll(async ({ request }) => {
+    await installPersonas(request, TEST_DIR, PERSONAS);
+  });
+
+  test('restart() takes the persona down and brings it back up', async ({
+    page
+  }) => {
+    const helpers = new TestHelpers({ dir: TEST_DIR, page });
+    await helpers.openChat();
+    await helpers.selectPersona(FixturePersona.Lifecycle);
+
+    // The persona posts its start marker when the chat first constructs it.
+    await expect
+      .poll(async () => helpers.countMessagesContaining(START_MARKER), {
+        timeout: 30000
+      })
+      .toBe(1);
+
+    // Trigger a restart from inside the persona (it calls self.restart()).
+    await helpers.send('restart');
+
+    // The stop message proves the old instance shut down.
+    await expect
+      .poll(async () => helpers.countMessagesContaining(STOP_MARKER), {
+        timeout: 30000
+      })
+      .toBe(1);
+
+    // A fresh start message proves a new instance came up under the same ID.
+    await expect
+      .poll(async () => helpers.countMessagesContaining(START_MARKER), {
+        timeout: 30000
+      })
+      .toBe(2);
+  });
+});

--- a/ui-tests/tests/test-helpers.ts
+++ b/ui-tests/tests/test-helpers.ts
@@ -41,7 +41,8 @@ export enum FixturePersona {
   SlashCommands = 'slash-commands',
   Models = 'models',
   SlowStream = 'slow-stream',
-  Refresher = 'refresher'
+  Refresher = 'refresher',
+  Lifecycle = 'lifecycle'
 }
 
 interface FixturePersonaInfo {
@@ -60,7 +61,8 @@ export const FIXTURE_PERSONAS: Record<FixturePersona, FixturePersonaInfo> = {
   [FixturePersona.SlashCommands]: { name: 'Slash Commands Persona' },
   [FixturePersona.Models]: { name: 'Models Persona' },
   [FixturePersona.SlowStream]: { name: 'Slow Stream Persona' },
-  [FixturePersona.Refresher]: { name: 'Refresher Persona' }
+  [FixturePersona.Refresher]: { name: 'Refresher Persona' },
+  [FixturePersona.Lifecycle]: { name: 'Lifecycle Persona' }
 };
 
 const PICKER = '.jp-jai-personaControls-persona-btn';
@@ -380,5 +382,16 @@ export class TestHelpers {
   /** The text of the latest rendered message (the persona's streaming reply). */
   async lastMessageText(): Promise<string> {
     return (await this.chat.locator(MESSAGE).last().textContent()) ?? '';
+  }
+
+  /** The text of every rendered message, in order. */
+  async allMessageTexts(): Promise<string[]> {
+    return this.chat.locator(MESSAGE).allTextContents();
+  }
+
+  /** How many rendered messages contain `text` as a substring. */
+  async countMessagesContaining(text: string): Promise<number> {
+    const texts = await this.allMessageTexts();
+    return texts.filter(t => t.includes(text)).length;
   }
 }


### PR DESCRIPTION
## Motivation

Today the only way to reload a persona is `/refresh-personas`, which tears down and rebuilds *every* persona in the chat. When one persona gets into a bad state, restarting all of them is heavier than needed — it disturbs the other personas, drops their awareness state, and re-runs all local persona loading. With v3.1 routing a target persona in message metadata (`metadata["to_persona"]`), we can restart just the one a command is addressed to, so this adds the API to do that.

## Summary

Adds a public `BasePersona.restart()` and the `PersonaManager.restart_persona(id)` it delegates to. Restarting shuts one persona instance down and reconstructs the same class under the same ID, leaving every other persona in the chat untouched. The persona list is republished afterwards (the reloaded persona gets a fresh Yjs awareness client ID) so the browser reconciles.

`restart()` is the single-persona counterpart to `refresh_personas()`. Unlike refresh, it does not reload persona code from disk — it reconstructs the class that is currently installed, bringing the persona back up in a clean state.

This is the provider side of the `/restart` chat command; the command itself lives in jupyter-ai-contrib/jupyter-ai-chat-commands (companion PR, which bumps its floor to this release).

## Technical details

`restart_persona` mirrors `shutdown_personas`: it drains the YChat background tasks before shutting the persona down (so no transaction lock survives into the reconstruction), then rebuilds and republishes. If reconstruction raises, the persona is dropped from the chat and the list is republished so the UI reflects reality, and the error is surfaced as a system message.

`restart()` is marked as an available-to-consumers member so it carries a doc contract level like the rest of the persona API.

Known edge case, not addressed here: an ACP persona (`BaseAcpPersona` in jupyter-ai-acp-client) shares one agent subprocess across all chat sessions and only terminates it once all chats close. So `/restart` on an ACP persona restarts the persona instance but not the shared subprocess unless it happens to be the last chat.

## Testing

Unit tests for the delegation and the manager's restart/rebuild/failure paths, plus a Galata E2E that restarts a lifecycle fixture persona (which posts a message on start and on stop) and asserts it goes down and comes back up. Ran the full persona-manager E2E suite green locally.

cc @vincentye38