### PR TITLE
Convert awareness model field comments to attribute docstrings

### DIFF
--- a/jupyter_ai_persona_manager/awareness_models.py
+++ b/jupyter_ai_persona_manager/awareness_models.py
@@ -31,10 +31,12 @@ class PersonaOption(BaseModel):
     id: str
     name: str
     avatar_url: str | None = None
-    # The Yjs client ID of this persona's awareness client. Persona client IDs
-    # are dynamic (they change as personas load/reload), so the manager reports
-    # each one here to let the browser look up a persona's awareness slot in O(1).
     yjs_client_id: int
+    """
+    The Yjs client ID of this persona's awareness client. Persona client IDs
+    are dynamic (they change as personas load/reload), so the manager reports
+    each one here to let the browser look up a persona's awareness slot in O(1).
+    """
 
 
 class ModelOption(BaseModel):
@@ -60,10 +62,10 @@ class SettingConfiguration(BaseModel):
     general settings (rendered separately). The list order controls UI order.
     """
 
-    # ID of the setting, e.g. "agent_mode".
     id: str
-    # The current value, or None to indicate the persona's default.
+    """ID of the setting, e.g. "agent_mode"."""
     current: str | None = None
+    """The current value, or None to indicate the persona's default."""
     name: str | None = None
     description: str | None = None
     options: list[SettingOption] = Field(default_factory=list)
@@ -72,46 +74,62 @@ class SettingConfiguration(BaseModel):
 class ModelConfiguration(BaseModel):
     """The persona's current model, its options, and its model settings."""
 
-    # The current model ID, or None to indicate the persona's default.
     current: str | None = None
+    """The current model ID, or None to indicate the persona's default."""
     options: list[ModelOption] = Field(default_factory=list)
-    # Settings that should render near the model picker (ACP `model_config`).
     settings: list[SettingConfiguration] = Field(default_factory=list)
+    """Settings that should render near the model picker (ACP ``model_config``)."""
 
 
 class Usage(BaseModel):
     """Token and cost usage reported by a persona for the current session."""
 
-    # Live context-window snapshot. Unlike the counters below, these can
-    # decrease during a session (e.g. after the agent compacts context).
-    context_tokens: int | None = None  # tokens currently in the window
-    context_size: int | None = None  # total window size
-    # Context fill as a bare percentage (0-100), the fallback for agents that
-    # report only a percentage with no token counts (e.g. kiro-cli). Precedence
-    # contract for consumers: when `context_tokens`/`context_size` are present,
-    # derive the percentage from them and ignore this field; read this field
-    # only when they are absent.
+    context_tokens: int | None = None
+    """
+    Tokens currently in the context window. Part of the live context-window
+    snapshot: unlike the cumulative counters below, ``context_tokens`` and
+    ``context_size`` can decrease during a session (e.g. after the agent
+    compacts context).
+    """
+    context_size: int | None = None
+    """Total context-window size. See :attr:`context_tokens`."""
     context_percent: float | None = None
+    """
+    Context fill as a bare percentage (0-100), the fallback for agents that
+    report only a percentage with no token counts (e.g. kiro-cli). Precedence
+    contract for consumers: when ``context_tokens``/``context_size`` are
+    present, derive the percentage from them and ignore this field; read this
+    field only when they are absent.
+    """
 
-    # Cumulative token counts for the session.
     input_tokens: int | None = None
+    """Cumulative count of input tokens for the session."""
     output_tokens: int | None = None
+    """Cumulative count of output tokens for the session."""
     cached_read_tokens: int | None = None
+    """Cumulative count of tokens read from the prompt cache this session."""
     cached_write_tokens: int | None = None
+    """Cumulative count of tokens written to the prompt cache this session."""
     thought_tokens: int | None = None
+    """Cumulative count of reasoning ("thinking") tokens for the session."""
     total_tokens: int | None = None
+    """Cumulative count of all tokens for the session."""
 
-    # Cumulative session cost. The currency is an ISO 4217 code (e.g. "USD")
-    # or, for agents that meter in their own unit, that unit's plural name
-    # (e.g. "credits").
     cost_amount: float | None = None
+    """Cumulative session cost, expressed in :attr:`cost_currency`."""
     cost_currency: str | None = None
+    """
+    The currency of :attr:`cost_amount`: an ISO 4217 code (e.g. "USD") or, for
+    agents that meter in their own unit, that unit's plural name (e.g.
+    "credits").
+    """
 
 
 class CommandOption(BaseModel):
     """One slash command advertised by a persona."""
 
-    name: str  # includes leading "/", e.g. "/compact"
+    name: str
+    """The command name, including the leading "/", e.g. "/compact"."""
     description: str | None = None
 
 

--- a/jupyter_ai_persona_manager/awareness_models.py
+++ b/jupyter_ai_persona_manager/awareness_models.py
@@ -29,8 +29,11 @@ class PersonaOption(BaseModel):
     """One persona in the chat, as advertised in the persona selector."""
 
     id: str
+    """Stable unique identifier for the persona (e.g. its class-derived ID)."""
     name: str
+    """Human-readable display name shown in the selector (e.g. "Jupyternaut")."""
     avatar_url: str | None = None
+    """URL that serves the persona's avatar image, or None if it has no avatar."""
     yjs_client_id: int
     """
     The Yjs client ID of this persona's awareness client. Persona client IDs
@@ -43,16 +46,22 @@ class ModelOption(BaseModel):
     """One selectable model."""
 
     id: str
+    """The model's unique identifier, used when selecting it (e.g. via :class:`ModelSpec`)."""
     name: str | None = None
+    """Human-readable label for the model; falls back to :attr:`id` when None."""
     description: str | None = None
+    """Optional longer description shown alongside the model in the picker."""
 
 
 class SettingOption(BaseModel):
     """One selectable value for a setting."""
 
     id: str
+    """The option's unique identifier, used as the selected value for its setting."""
     name: str | None = None
+    """Human-readable label for the option; falls back to :attr:`id` when None."""
     description: str | None = None
+    """Optional longer description shown alongside the option in the picker."""
 
 
 class SettingConfiguration(BaseModel):
@@ -67,8 +76,11 @@ class SettingConfiguration(BaseModel):
     current: str | None = None
     """The current value, or None to indicate the persona's default."""
     name: str | None = None
+    """Human-readable label for the setting; falls back to :attr:`id` when None."""
     description: str | None = None
+    """Optional longer description explaining what the setting controls."""
     options: list[SettingOption] = Field(default_factory=list)
+    """The selectable values for this setting, in display order."""
 
 
 class ModelConfiguration(BaseModel):
@@ -77,6 +89,7 @@ class ModelConfiguration(BaseModel):
     current: str | None = None
     """The current model ID, or None to indicate the persona's default."""
     options: list[ModelOption] = Field(default_factory=list)
+    """The models the persona offers, in display order."""
     settings: list[SettingConfiguration] = Field(default_factory=list)
     """Settings that should render near the model picker (ACP ``model_config``)."""
 
@@ -131,6 +144,7 @@ class CommandOption(BaseModel):
     name: str
     """The command name, including the leading "/", e.g. "/compact"."""
     description: str | None = None
+    """Optional short description of what the command does, shown in the UI."""
 
 
 ################################################
@@ -147,4 +161,9 @@ class ModelSpec(BaseModel):
     """
 
     id: str | None = None
+    """The selected model ID, or None to keep the persona's current model."""
     settings: dict[str, str | None] = Field(default_factory=dict)
+    """
+    Maps each model-setting ID to its selected option ID, or to None to keep
+    that setting's current value.
+    """


### PR DESCRIPTION
## Motivation

Fixes #78

The field-level explanations on the awareness models in `awareness_models.py` lived in inline `#` comments. Those models are rendered on the contributor docs API page via `autopydantic_model`, but autodoc doesn't see inline comments, so the field descriptions never made it into the generated documentation. The `context_percent` precedence rule and the `cost_currency` unit semantics clarified in #75 are exactly the kind of thing a consumer reading the API reference needs.

## Summary

Moves the inline comments on the awareness model fields (`PersonaOption`, `SettingConfiguration`, `ModelConfiguration`, `Usage`, `CommandOption`) into attribute docstrings — the triple-quoted string that follows a field, which is the same convention `BasePersona` already uses. sphinx-autodoc-pydantic renders these into the field summaries on the API page.

This is a docs-only pass: no field defaults, types, or names change, and the meaning of each comment is preserved. The attribute docstrings do not affect the pydantic JSON schema.

## Testing

Ran the existing pytest suite (all passing) and built the `Usage`/`PersonaOption`/`CommandOption` models through sphinx-autodoc-pydantic with the same config the jupyter-ai docs use, confirming every field description now renders.