### PR TITLE
Title control dropdowns, fix menu keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",
         "@types/react-addons-linked-state-mixin": "^0.14.22",
+        "@types/react-dom": "^18.0.0",
         "@typescript-eslint/eslint-plugin": "^6.1.0",
         "@typescript-eslint/parser": "^6.1.0",
         "css-loader": "^6.7.1",

--- a/src/__tests__/persona-controls-menus.spec.tsx
+++ b/src/__tests__/persona-controls-menus.spec.tsx
@@ -1,0 +1,161 @@
+/**
+ * Renders the control menus and pins their user-observable contract: each
+ * dropdown opens titled by its control's heading, the heading names the menu
+ * for assistive tech without joining keyboard traversal, and arrow keys,
+ * type-ahead, and Enter drive the choice rows.
+ */
+import React from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { Control, ControlItem, OverflowMenu } from '../persona-controls';
+
+// React 18.3 ships `React.act`, which the installed @types/react (18.0) does
+// not declare yet.
+const { act } = React as unknown as { act: (callback: () => void) => void };
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const SUBHEADER_SELECTOR = 'li.jp-jai-controlMenu-subheader';
+
+function modelControl(selection: string | null): Control {
+  return {
+    id: '__model__',
+    kind: 'model',
+    label: 'Model',
+    current: 'alpha',
+    selection,
+    options: [
+      { id: 'alpha', name: 'Alpha', description: null },
+      { id: 'beta', name: 'Beta', description: null }
+    ]
+  };
+}
+
+describe('control menus', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function menu(): HTMLElement {
+    return document.querySelector('ul[role="menu"]') as HTMLElement;
+  }
+
+  function focused(): HTMLElement {
+    return document.activeElement as HTMLElement;
+  }
+
+  function press(key: string): void {
+    act(() => {
+      focused().dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      );
+    });
+  }
+
+  describe('control dropdown', () => {
+    function openMenu(
+      control: Control,
+      onSelect: (value: string | null) => void = () => undefined
+    ): void {
+      act(() => {
+        root.render(<ControlItem control={control} onSelect={onSelect} />);
+      });
+      act(() => {
+        (container.querySelector('button') as HTMLElement).dispatchEvent(
+          new MouseEvent('click', { bubbles: true })
+        );
+      });
+    }
+
+    it('opens titled by a heading that names the menu', () => {
+      openMenu(modelControl('beta'));
+      const heading = document.querySelector(SUBHEADER_SELECTOR) as HTMLElement;
+      expect(heading.textContent).toBe('Model');
+      expect(heading.hasAttribute('tabindex')).toBe(false);
+      expect(heading.id).toBeTruthy();
+      expect(menu().getAttribute('aria-labelledby')).toBe(heading.id);
+    });
+
+    it('focuses the selected row and moves focus with the keyboard', () => {
+      openMenu(modelControl('beta'));
+      // Rows: heading, "Default (Alpha)", "Alpha", "Beta"; "Beta" is selected.
+      expect(focused().textContent).toBe('Beta');
+      expect(focused().getAttribute('role')).toBe('menuitem');
+      // Wrapping from the last row skips the heading to the first choice row.
+      press('ArrowDown');
+      expect(focused().textContent).toBe('Default (Alpha)');
+      press('ArrowDown');
+      expect(focused().textContent).toBe('Alpha');
+      // Type-ahead: "b" jumps to Beta; "m" matches only the heading text
+      // ("Model"), which never takes focus.
+      press('b');
+      expect(focused().textContent).toBe('Beta');
+      press('m');
+      expect(focused().textContent).toBe('Beta');
+    });
+
+    it('activates the focused row with Enter', () => {
+      const onSelect = jest.fn();
+      openMenu(modelControl(null), onSelect);
+      press('ArrowDown');
+      press('ArrowDown');
+      press('Enter');
+      expect(onSelect).toHaveBeenCalledWith('beta');
+    });
+  });
+
+  describe('overflow menu', () => {
+    it('is labeled and arrows skip the section headings', () => {
+      const first: Control = {
+        id: 'a',
+        kind: 'setting',
+        label: 'Aaa',
+        current: null,
+        selection: 'a1',
+        options: [{ id: 'a1', name: 'A one', description: null }]
+      };
+      const second: Control = {
+        id: 'b',
+        kind: 'setting',
+        label: 'Bbb',
+        current: null,
+        selection: 'stale',
+        options: [{ id: 'b1', name: 'B one', description: null }]
+      };
+      const anchor = document.createElement('button');
+      document.body.appendChild(anchor);
+      act(() => {
+        root.render(
+          <OverflowMenu
+            controls={[first, second]}
+            anchor={anchor}
+            onClose={() => undefined}
+            onChange={() => undefined}
+          />
+        );
+      });
+      expect(menu().getAttribute('aria-label')).toBe('More controls');
+      const headings = Array.from(
+        document.querySelectorAll(SUBHEADER_SELECTOR)
+      ).map(h => h.textContent);
+      expect(headings).toEqual(['Aaa', 'Bbb']);
+      // "A one" is the only selected row; ArrowDown crosses the "Bbb" heading
+      // to the next section's first choice row.
+      expect(focused().textContent).toBe('A one');
+      press('ArrowDown');
+      expect(focused().textContent).toBe('Default');
+      anchor.remove();
+    });
+  });
+});

--- a/src/__tests__/persona-controls-menus.spec.tsx
+++ b/src/__tests__/persona-controls-menus.spec.tsx
@@ -97,12 +97,26 @@ describe('control menus', () => {
       expect(focused().textContent).toBe('Default (Alpha)');
       press('ArrowDown');
       expect(focused().textContent).toBe('Alpha');
-      // Type-ahead: "b" jumps to Beta; "m" matches only the heading text
-      // ("Model"), which never takes focus.
+      // Type-ahead: "b" jumps to Beta.
       press('b');
       expect(focused().textContent).toBe('Beta');
+    });
+
+    it('leaves focus in place when type-ahead matches only the heading', () => {
+      openMenu(modelControl('beta'));
+      // First key after open, so it cannot buffer onto a previous press: "m"
+      // matches the heading ("Model") and no choice row, and the heading
+      // never takes focus.
       press('m');
       expect(focused().textContent).toBe('Beta');
+    });
+
+    it('falls back to the first choice row when the selection is stale', () => {
+      // A selection id the persona no longer advertises leaves no row
+      // selected; initial focus then skips the heading to the first row.
+      openMenu(modelControl('stale'));
+      expect(focused().textContent).toBe('Default (Alpha)');
+      expect(focused().getAttribute('role')).toBe('menuitem');
     });
 
     it('activates the focused row with Enter', () => {

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -280,14 +280,24 @@ function ChoiceMenuItem(props: {
   selected: boolean;
   onSelect: () => void;
 }): JSX.Element {
-  const { primary, selected, onSelect } = props;
+  // MenuList clones the row it picks for initial focus with extra props
+  // (tabIndex, autoFocus); forward them to the MenuItem, or no row is ever
+  // focused and the menu's arrow-key and type-ahead handling never engages.
+  const {
+    primary,
+    description: rawDescription,
+    selected,
+    onSelect,
+    ...menuItemProps
+  } = props;
   const description =
-    props.description &&
-    props.description.trim().toLowerCase() !== primary.trim().toLowerCase()
-      ? props.description
+    rawDescription &&
+    rawDescription.trim().toLowerCase() !== primary.trim().toLowerCase()
+      ? rawDescription
       : null;
   return (
     <MenuItem
+      {...menuItemProps}
       selected={selected}
       onClick={onSelect}
       title={description ?? undefined}

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -332,6 +332,10 @@ function ControlSubheader(props: { label: string }): JSX.Element {
   );
 }
 
+// MUI's MenuList skips initial focus for children whose type carries this
+// static; ListSubheader's own copy is hidden behind the wrapper.
+ControlSubheader.muiSkipListHighlight = true;
+
 /**
  * A dropdown for a control, titled with the control's label. The first choice
  * row is "Default" (selection = null); the rest are the persona's advertised

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -319,8 +319,23 @@ function defaultChoiceLabel(control: Control): string {
 }
 
 /**
- * A dropdown for a control. The first row is "Default" (selection = null); the
- * rest are the persona's advertised options (selection = that option's id).
+ * The uppercase group label used in control menus: it titles a control's own
+ * dropdown and labels each control's section in the overflow menu. Rendered
+ * with MUI's `ListSubheader`, which has no tabindex, so arrow-key focus skips
+ * it and the menu stays keyboard-navigable.
+ */
+function ControlSubheader(props: { label: string }): JSX.Element {
+  return (
+    <ListSubheader disableSticky className={`${MENU_CLASS}-subheader`}>
+      {props.label}
+    </ListSubheader>
+  );
+}
+
+/**
+ * A dropdown for a control, titled with the control's label. The first choice
+ * row is "Default" (selection = null); the rest are the persona's advertised
+ * options (selection = that option's id).
  */
 function ControlItem(props: {
   control: Control;
@@ -349,6 +364,7 @@ function ControlItem(props: {
         onClose={() => setAnchor(null)}
         {...menuAnchorProps}
       >
+        <ControlSubheader label={control.label} />
         <ChoiceMenuItem
           primary={defaultChoiceLabel(control)}
           description={null}
@@ -377,10 +393,8 @@ function ControlItem(props: {
 
 /**
  * The overflow popover: controls that did not fit inline, shown as a single flat
- * menu (no nested dropdowns). Each control renders as a `ListSubheader` group
- * label followed by its Default row and choices. Using MUI primitives keeps the
- * menu keyboard-navigable: `ListSubheader` has no tabindex so arrow-key focus
- * skips it.
+ * menu (no nested dropdowns). Each control renders as a group label followed by
+ * its Default row and choices.
  */
 function OverflowMenu(props: {
   controls: Control[];
@@ -397,13 +411,7 @@ function OverflowMenu(props: {
       {...menuAnchorProps}
     >
       {controls.flatMap(control => [
-        <ListSubheader
-          key={`${control.id}-label`}
-          disableSticky
-          className={`${SELECTOR_CLASS}-overflow-subheader`}
-        >
-          {control.label}
-        </ListSubheader>,
+        <ControlSubheader key={`${control.id}-label`} label={control.label} />,
         <ChoiceMenuItem
           key={`${control.id}-default`}
           primary={defaultChoiceLabel(control)}

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState
@@ -334,9 +335,13 @@ function defaultChoiceLabel(control: Control): string {
  * with MUI's `ListSubheader`, which has no tabindex, so arrow-key focus skips
  * it and the menu stays keyboard-navigable.
  */
-function ControlSubheader(props: { label: string }): JSX.Element {
+function ControlSubheader(props: { label: string; id?: string }): JSX.Element {
   return (
-    <ListSubheader disableSticky className={`${MENU_CLASS}-subheader`}>
+    <ListSubheader
+      id={props.id}
+      disableSticky
+      className={`${MENU_CLASS}-subheader`}
+    >
       {props.label}
     </ListSubheader>
   );
@@ -357,6 +362,10 @@ function ControlItem(props: {
 }): JSX.Element {
   const { control, onSelect } = props;
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  // The heading names the menu for assistive tech: the subheader itself is a
+  // roleless, never-focused list row, so without this wiring the popup has no
+  // accessible name at all.
+  const headingId = useId();
   return (
     <>
       <Button
@@ -376,9 +385,10 @@ function ControlItem(props: {
         anchorEl={anchor}
         open={!!anchor}
         onClose={() => setAnchor(null)}
+        MenuListProps={{ 'aria-labelledby': headingId }}
         {...menuAnchorProps}
       >
-        <ControlSubheader label={control.label} />
+        <ControlSubheader id={headingId} label={control.label} />
         <ChoiceMenuItem
           primary={defaultChoiceLabel(control)}
           description={null}
@@ -422,6 +432,7 @@ function OverflowMenu(props: {
       anchorEl={anchor}
       open={!!anchor}
       onClose={onClose}
+      MenuListProps={{ 'aria-label': 'More controls' }}
       {...menuAnchorProps}
     >
       {controls.flatMap(control => [

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -354,9 +354,9 @@ ControlSubheader.muiSkipListHighlight = true;
 /**
  * A dropdown for a control, titled with the control's label. The first choice
  * row is "Default" (selection = null); the rest are the persona's advertised
- * options (selection = that option's id).
+ * options (selection = that option's id). Exported for tests.
  */
-function ControlItem(props: {
+export function ControlItem(props: {
   control: Control;
   onSelect: (value: string | null) => void;
 }): JSX.Element {
@@ -418,9 +418,9 @@ function ControlItem(props: {
 /**
  * The overflow popover: controls that did not fit inline, shown as a single flat
  * menu (no nested dropdowns). Each control renders as a group label followed by
- * its Default row and choices.
+ * its Default row and choices. Exported for tests.
  */
-function OverflowMenu(props: {
+export function OverflowMenu(props: {
   controls: Control[];
   anchor: HTMLElement | null;
   onClose: () => void;

--- a/style/base.css
+++ b/style/base.css
@@ -278,10 +278,11 @@
   flex-shrink: 0;
 }
 
-/* overflow popover: an uppercase group label above each overflowed control's
-   choices, with a hairline divider and top spacing separating the sections.
-   Scoped under the paper to win over MUI's ListSubheader defaults. */
-.jp-jai-controlMenu-paper .jp-jai-personaControls-overflow-subheader {
+/* Control menu group label: an uppercase heading above a control's choices.
+   It titles each control's own dropdown; in the overflow popover a hairline
+   divider and top spacing separate the controls' sections. Scoped under the
+   paper to win over MUI's ListSubheader defaults. */
+.jp-jai-controlMenu-paper .jp-jai-controlMenu-subheader {
   margin-top: 8px;
   padding: 8px 12px 2px;
   border-top: 1px solid var(--jp-border-color2);
@@ -295,9 +296,9 @@
   background-color: var(--jp-layout-color1);
 }
 
-/* first section sits flush at the top, no divider or extra gap above it. */
-.jp-jai-controlMenu-paper
-  .jp-jai-personaControls-overflow-subheader:first-child {
+/* The first (or only) label sits flush at the top, no divider or extra gap
+   above it. */
+.jp-jai-controlMenu-paper .jp-jai-controlMenu-subheader:first-child {
   margin-top: 0;
   border-top: none;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -362,8 +362,8 @@
   white-space: nowrap;
 }
 
-/* Usage popover card: labeled sections in the overflow-subheader style, then
-   one row per quantity, label muted and value right-aligned. */
+/* Usage popover card: labeled sections in the control menu's subheader style,
+   then one row per quantity, label muted and value right-aligned. */
 .jp-jai-usage-card {
   padding: 8px 12px;
   min-width: 220px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,6 +2195,7 @@ __metadata:
     "@types/json-schema": ^7.0.11
     "@types/react": ^18.0.26
     "@types/react-addons-linked-state-mixin": ^0.14.22
+    "@types/react-dom": ^18.0.0
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
     css-loader: ^6.7.1
@@ -4144,6 +4145,15 @@ __metadata:
     "@types/create-react-class": "*"
     "@types/react": "*"
   checksum: a78007698a236335a50c74ddd27669028213ff363219f97a6ea1f000ddb8714c83838002ea07c33024f964112a229e447127b457fa3f9b3db352dd41d6b8d328
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:^18.0.0":
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
+  peerDependencies:
+    "@types/react": ^18.0.0
+  checksum: c8b63ec944d2a68992b4dba474003fe55ee1d949c4b9c8fe97eecb2290de23f76acfb670b2f7ceb46a5fc8e46808d1745369b03edda48a7a0cf730eff4c5d315
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

A control button in the chat input toolbar shows only its current value (e.g. `claude-fable-5[1m]`, `Default`), and its dropdown shows only choice rows. Nothing in the popup says which control is being set, so with several adjacent controls (model, mode, effort) the popups look alike. The overflow "..." menu already labels each control's section with a group heading, so inline and overflowed controls also read differently.

Working on this surfaced two adjacent defects. Keyboard navigation in these menus was dead: no row ever received focus when a menu opened, so arrow keys, type-ahead, and Enter did nothing. And the popups had no accessible name, so screen readers announced an unnamed menu.

## Changes

- Each control dropdown now opens with the control's label as its heading, in the same style the overflow menu uses for its section labels. The heading is extracted into a shared `ControlSubheader` component, and its CSS class renames from `jp-jai-personaControls-overflow-subheader` to `jp-jai-controlMenu-subheader` since it now labels both menus. It carries MUI's `muiSkipListHighlight` static so menus skip it when placing initial focus.
- Keyboard navigation is fixed: `ChoiceMenuItem` now forwards the focus props MUI injects into the row it picks for initial focus. Dropping them left focus on the menu container, where the list's key handling never engaged. A menu now opens focused on its selected row, and arrow keys, Home/End, type-ahead, and Enter work.
- The menus get accessible names: each dropdown is named by its heading via `aria-labelledby`, and the overflow menu carries `aria-label="More controls"` to match its trigger.
- Component testing now works in this package: the missing `@types/react-dom` dev dependency kept `react-dom` imports from typechecking, and no spec rendered a component before (only exported pure functions were tested). `ControlItem` and `OverflowMenu` are exported for tests.

The persona picker popup and the usage popover are unchanged.

## Testing

Added 4 component tests (`src/__tests__/persona-controls-menus.spec.tsx`) rendering the real menus against MUI, no mocks. They pin the heading (titles and names the menu, never takes focus), initial focus on the selected row, arrow-key and type-ahead movement, Enter activation, and the overflow menu's label and sections.

Manually verified in JupyterLab, light and dark themes: each dropdown opens titled with its label in the overflow heading style, and keyboard navigation works (arrows, type-ahead, Enter, Escape).

## Demo 

Keyboard navigation
<img width="1496" height="902" alt="keyboard-nav" src="https://github.com/user-attachments/assets/290c6ce6-94a3-45e6-bed5-1d4b12634710" />

<img width="1495" height="910" alt="Screenshot 2026-07-23 at 8 35 40 AM" src="https://github.com/user-attachments/assets/0b3d866b-bb6a-44e1-be8c-f69ec8e3ca8c" />

<img width="1493" height="917" alt="Screenshot 2026-07-23 at 8 36 21 AM" src="https://github.com/user-attachments/assets/ee95fff1-f87f-48b2-84d5-4f03692adc54" />
