### PR TITLE
Rename control menu components, adopt React Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",
         "@jupyterlab/testutils": "^4.0.0",
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.0",
         "@types/jest": "^29.2.0",
         "@types/json-schema": "^7.0.11",
         "@types/react": "^18.0.26",

--- a/src/__tests__/persona-controls-menus.spec.tsx
+++ b/src/__tests__/persona-controls-menus.spec.tsx
@@ -4,17 +4,14 @@
  * for assistive tech without joining keyboard traversal, and arrow keys,
  * type-ahead, and Enter drive the choice rows.
  */
-import React, { act } from 'react';
-import { createRoot, Root } from 'react-dom/client';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   Control,
   ControlMenu,
   OverflowControlsMenu
 } from '../persona-controls';
-
-(
-  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
-).IS_REACT_ACT_ENVIRONMENT = true;
 
 const SUBHEADER_SELECTOR = 'li.jp-jai-controlMenu-subheader';
 
@@ -32,101 +29,74 @@ function modelControl(selection: string | null): Control {
   };
 }
 
+function heading(): HTMLElement {
+  return document.querySelector(SUBHEADER_SELECTOR) as HTMLElement;
+}
+
+function focused(): HTMLElement {
+  return document.activeElement as HTMLElement;
+}
+
 describe('control menus', () => {
-  let container: HTMLDivElement;
-  let root: Root;
-
-  beforeEach(() => {
-    container = document.createElement('div');
-    document.body.appendChild(container);
-    root = createRoot(container);
-  });
-
-  afterEach(async () => {
-    await act(async () => {
-      root.unmount();
-    });
-    container.remove();
-  });
-
-  function menu(): HTMLElement {
-    return document.querySelector('ul[role="menu"]') as HTMLElement;
-  }
-
-  function focused(): HTMLElement {
-    return document.activeElement as HTMLElement;
-  }
-
-  async function press(key: string): Promise<void> {
-    await act(async () => {
-      focused().dispatchEvent(
-        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
-      );
-    });
-  }
-
   describe('control dropdown', () => {
     async function openMenu(
       control: Control,
       onSelect: (value: string | null) => void = () => undefined
-    ): Promise<void> {
-      await act(async () => {
-        root.render(<ControlMenu control={control} onSelect={onSelect} />);
-      });
-      await act(async () => {
-        (container.querySelector('button') as HTMLElement).dispatchEvent(
-          new MouseEvent('click', { bubbles: true })
-        );
-      });
+    ): Promise<ReturnType<typeof userEvent.setup>> {
+      const user = userEvent.setup();
+      render(<ControlMenu control={control} onSelect={onSelect} />);
+      await user.click(screen.getByRole('button'));
+      return user;
     }
 
     it('opens titled by a heading that names the menu', async () => {
       await openMenu(modelControl('beta'));
-      const heading = document.querySelector(SUBHEADER_SELECTOR) as HTMLElement;
-      expect(heading.textContent).toBe('Model');
-      expect(heading.hasAttribute('tabindex')).toBe(false);
-      expect(heading.id).toBeTruthy();
-      expect(menu().getAttribute('aria-labelledby')).toBe(heading.id);
+      expect(heading().textContent).toBe('Model');
+      expect(heading().hasAttribute('tabindex')).toBe(false);
+      expect(heading().id).toBeTruthy();
+      expect(screen.getByRole('menu').getAttribute('aria-labelledby')).toBe(
+        heading().id
+      );
     });
 
     it('focuses the selected row and moves focus with the keyboard', async () => {
-      await openMenu(modelControl('beta'));
+      const user = await openMenu(modelControl('beta'));
       // Rows: heading, "Default (Alpha)", "Alpha", "Beta"; "Beta" is selected.
-      expect(focused().textContent).toBe('Beta');
-      expect(focused().getAttribute('role')).toBe('menuitem');
+      expect(focused()).toBe(screen.getByRole('menuitem', { name: 'Beta' }));
       // Wrapping from the last row skips the heading to the first choice row.
-      await press('ArrowDown');
-      expect(focused().textContent).toBe('Default (Alpha)');
-      await press('ArrowDown');
-      expect(focused().textContent).toBe('Alpha');
+      await user.keyboard('{ArrowDown}');
+      expect(focused()).toBe(
+        screen.getByRole('menuitem', { name: 'Default (Alpha)' })
+      );
+      await user.keyboard('{ArrowDown}');
+      expect(focused()).toBe(screen.getByRole('menuitem', { name: 'Alpha' }));
       // Type-ahead: "b" jumps to Beta.
-      await press('b');
-      expect(focused().textContent).toBe('Beta');
+      await user.keyboard('b');
+      expect(focused()).toBe(screen.getByRole('menuitem', { name: 'Beta' }));
     });
 
     it('leaves focus in place when type-ahead matches only the heading', async () => {
-      await openMenu(modelControl('beta'));
+      const user = await openMenu(modelControl('beta'));
       // First key after open, so it cannot buffer onto a previous press: "m"
       // matches the heading ("Model") and no choice row, and the heading
       // never takes focus.
-      await press('m');
-      expect(focused().textContent).toBe('Beta');
+      await user.keyboard('m');
+      expect(focused()).toBe(screen.getByRole('menuitem', { name: 'Beta' }));
     });
 
     it('falls back to the first choice row when the selection is stale', async () => {
       // A selection id the persona no longer advertises leaves no row
       // selected; initial focus then skips the heading to the first row.
       await openMenu(modelControl('stale'));
-      expect(focused().textContent).toBe('Default (Alpha)');
-      expect(focused().getAttribute('role')).toBe('menuitem');
+      expect(focused()).toBe(
+        screen.getByRole('menuitem', { name: 'Default (Alpha)' })
+      );
     });
 
     it('activates the focused row with Enter', async () => {
       const onSelect = jest.fn();
-      await openMenu(modelControl(null), onSelect);
-      await press('ArrowDown');
-      await press('ArrowDown');
-      await press('Enter');
+      const user = await openMenu(modelControl(null), onSelect);
+      await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
       expect(onSelect).toHaveBeenCalledWith('beta');
     });
   });
@@ -145,32 +115,35 @@ describe('control menus', () => {
         id: 'b',
         kind: 'setting',
         label: 'Bbb',
-        current: null,
+        current: 'b1',
         selection: 'stale',
         options: [{ id: 'b1', name: 'B one', description: null }]
       };
+      const user = userEvent.setup();
       const anchor = document.createElement('button');
       document.body.appendChild(anchor);
-      await act(async () => {
-        root.render(
-          <OverflowControlsMenu
-            controls={[first, second]}
-            anchor={anchor}
-            onClose={() => undefined}
-            onChange={() => undefined}
-          />
-        );
-      });
-      expect(menu().getAttribute('aria-label')).toBe('More controls');
+      render(
+        <OverflowControlsMenu
+          controls={[first, second]}
+          anchor={anchor}
+          onClose={() => undefined}
+          onChange={() => undefined}
+        />
+      );
+      expect(screen.getByRole('menu').getAttribute('aria-label')).toBe(
+        'More controls'
+      );
       const headings = Array.from(
         document.querySelectorAll(SUBHEADER_SELECTOR)
       ).map(h => h.textContent);
       expect(headings).toEqual(['Aaa', 'Bbb']);
       // "A one" is the only selected row; ArrowDown crosses the "Bbb" heading
       // to the next section's first choice row.
-      expect(focused().textContent).toBe('A one');
-      await press('ArrowDown');
-      expect(focused().textContent).toBe('Default');
+      expect(focused()).toBe(screen.getByRole('menuitem', { name: 'A one' }));
+      await user.keyboard('{ArrowDown}');
+      expect(focused()).toBe(
+        screen.getByRole('menuitem', { name: 'Default (B one)' })
+      );
       anchor.remove();
     });
   });

--- a/src/__tests__/persona-controls-menus.spec.tsx
+++ b/src/__tests__/persona-controls-menus.spec.tsx
@@ -6,7 +6,11 @@
  */
 import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
-import { Control, ControlItem, OverflowMenu } from '../persona-controls';
+import {
+  Control,
+  ControlMenu,
+  OverflowControlsMenu
+} from '../persona-controls';
 
 // React 18.3 ships `React.act`, which the installed @types/react (18.0) does
 // not declare yet.
@@ -69,7 +73,7 @@ describe('control menus', () => {
       onSelect: (value: string | null) => void = () => undefined
     ): void {
       act(() => {
-        root.render(<ControlItem control={control} onSelect={onSelect} />);
+        root.render(<ControlMenu control={control} onSelect={onSelect} />);
       });
       act(() => {
         (container.querySelector('button') as HTMLElement).dispatchEvent(
@@ -151,7 +155,7 @@ describe('control menus', () => {
       document.body.appendChild(anchor);
       act(() => {
         root.render(
-          <OverflowMenu
+          <OverflowControlsMenu
             controls={[first, second]}
             anchor={anchor}
             onClose={() => undefined}

--- a/src/__tests__/persona-controls-menus.spec.tsx
+++ b/src/__tests__/persona-controls-menus.spec.tsx
@@ -4,17 +4,13 @@
  * for assistive tech without joining keyboard traversal, and arrow keys,
  * type-ahead, and Enter drive the choice rows.
  */
-import React from 'react';
+import React, { act } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import {
   Control,
   ControlMenu,
   OverflowControlsMenu
 } from '../persona-controls';
-
-// React 18.3 ships `React.act`, which the installed @types/react (18.0) does
-// not declare yet.
-const { act } = React as unknown as { act: (callback: () => void) => void };
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -46,8 +42,10 @@ describe('control menus', () => {
     root = createRoot(container);
   });
 
-  afterEach(() => {
-    act(() => root.unmount());
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
     container.remove();
   });
 
@@ -59,8 +57,8 @@ describe('control menus', () => {
     return document.activeElement as HTMLElement;
   }
 
-  function press(key: string): void {
-    act(() => {
+  async function press(key: string): Promise<void> {
+    await act(async () => {
       focused().dispatchEvent(
         new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
       );
@@ -68,22 +66,22 @@ describe('control menus', () => {
   }
 
   describe('control dropdown', () => {
-    function openMenu(
+    async function openMenu(
       control: Control,
       onSelect: (value: string | null) => void = () => undefined
-    ): void {
-      act(() => {
+    ): Promise<void> {
+      await act(async () => {
         root.render(<ControlMenu control={control} onSelect={onSelect} />);
       });
-      act(() => {
+      await act(async () => {
         (container.querySelector('button') as HTMLElement).dispatchEvent(
           new MouseEvent('click', { bubbles: true })
         );
       });
     }
 
-    it('opens titled by a heading that names the menu', () => {
-      openMenu(modelControl('beta'));
+    it('opens titled by a heading that names the menu', async () => {
+      await openMenu(modelControl('beta'));
       const heading = document.querySelector(SUBHEADER_SELECTOR) as HTMLElement;
       expect(heading.textContent).toBe('Model');
       expect(heading.hasAttribute('tabindex')).toBe(false);
@@ -91,50 +89,50 @@ describe('control menus', () => {
       expect(menu().getAttribute('aria-labelledby')).toBe(heading.id);
     });
 
-    it('focuses the selected row and moves focus with the keyboard', () => {
-      openMenu(modelControl('beta'));
+    it('focuses the selected row and moves focus with the keyboard', async () => {
+      await openMenu(modelControl('beta'));
       // Rows: heading, "Default (Alpha)", "Alpha", "Beta"; "Beta" is selected.
       expect(focused().textContent).toBe('Beta');
       expect(focused().getAttribute('role')).toBe('menuitem');
       // Wrapping from the last row skips the heading to the first choice row.
-      press('ArrowDown');
+      await press('ArrowDown');
       expect(focused().textContent).toBe('Default (Alpha)');
-      press('ArrowDown');
+      await press('ArrowDown');
       expect(focused().textContent).toBe('Alpha');
       // Type-ahead: "b" jumps to Beta.
-      press('b');
+      await press('b');
       expect(focused().textContent).toBe('Beta');
     });
 
-    it('leaves focus in place when type-ahead matches only the heading', () => {
-      openMenu(modelControl('beta'));
+    it('leaves focus in place when type-ahead matches only the heading', async () => {
+      await openMenu(modelControl('beta'));
       // First key after open, so it cannot buffer onto a previous press: "m"
       // matches the heading ("Model") and no choice row, and the heading
       // never takes focus.
-      press('m');
+      await press('m');
       expect(focused().textContent).toBe('Beta');
     });
 
-    it('falls back to the first choice row when the selection is stale', () => {
+    it('falls back to the first choice row when the selection is stale', async () => {
       // A selection id the persona no longer advertises leaves no row
       // selected; initial focus then skips the heading to the first row.
-      openMenu(modelControl('stale'));
+      await openMenu(modelControl('stale'));
       expect(focused().textContent).toBe('Default (Alpha)');
       expect(focused().getAttribute('role')).toBe('menuitem');
     });
 
-    it('activates the focused row with Enter', () => {
+    it('activates the focused row with Enter', async () => {
       const onSelect = jest.fn();
-      openMenu(modelControl(null), onSelect);
-      press('ArrowDown');
-      press('ArrowDown');
-      press('Enter');
+      await openMenu(modelControl(null), onSelect);
+      await press('ArrowDown');
+      await press('ArrowDown');
+      await press('Enter');
       expect(onSelect).toHaveBeenCalledWith('beta');
     });
   });
 
   describe('overflow menu', () => {
-    it('is labeled and arrows skip the section headings', () => {
+    it('is labeled and arrows skip the section headings', async () => {
       const first: Control = {
         id: 'a',
         kind: 'setting',
@@ -153,7 +151,7 @@ describe('control menus', () => {
       };
       const anchor = document.createElement('button');
       document.body.appendChild(anchor);
-      act(() => {
+      await act(async () => {
         root.render(
           <OverflowControlsMenu
             controls={[first, second]}
@@ -171,7 +169,7 @@ describe('control menus', () => {
       // "A one" is the only selected row; ArrowDown crosses the "Bbb" heading
       // to the next section's first choice row.
       expect(focused().textContent).toBe('A one');
-      press('ArrowDown');
+      await press('ArrowDown');
       expect(focused().textContent).toBe('Default');
       anchor.remove();
     });

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -335,7 +335,10 @@ function defaultChoiceLabel(control: Control): string {
  * with MUI's `ListSubheader`, which has no tabindex, so arrow-key focus skips
  * it and the menu stays keyboard-navigable.
  */
-function ControlSubheader(props: { label: string; id?: string }): JSX.Element {
+function ControlMenuSubheader(props: {
+  label: string;
+  id?: string;
+}): JSX.Element {
   return (
     <ListSubheader
       id={props.id}
@@ -349,14 +352,14 @@ function ControlSubheader(props: { label: string; id?: string }): JSX.Element {
 
 // MUI's MenuList skips initial focus for children whose type carries this
 // static; ListSubheader's own copy is hidden behind the wrapper.
-ControlSubheader.muiSkipListHighlight = true;
+ControlMenuSubheader.muiSkipListHighlight = true;
 
 /**
  * A dropdown for a control, titled with the control's label. The first choice
  * row is "Default" (selection = null); the rest are the persona's advertised
  * options (selection = that option's id). Exported for tests.
  */
-export function ControlItem(props: {
+export function ControlMenu(props: {
   control: Control;
   onSelect: (value: string | null) => void;
 }): JSX.Element {
@@ -388,7 +391,7 @@ export function ControlItem(props: {
         MenuListProps={{ 'aria-labelledby': headingId }}
         {...menuAnchorProps}
       >
-        <ControlSubheader id={headingId} label={control.label} />
+        <ControlMenuSubheader id={headingId} label={control.label} />
         <ChoiceMenuItem
           primary={defaultChoiceLabel(control)}
           description={null}
@@ -420,7 +423,7 @@ export function ControlItem(props: {
  * menu (no nested dropdowns). Each control renders as a group label followed by
  * its Default row and choices. Exported for tests.
  */
-export function OverflowMenu(props: {
+export function OverflowControlsMenu(props: {
   controls: Control[];
   anchor: HTMLElement | null;
   onClose: () => void;
@@ -436,7 +439,10 @@ export function OverflowMenu(props: {
       {...menuAnchorProps}
     >
       {controls.flatMap(control => [
-        <ControlSubheader key={`${control.id}-label`} label={control.label} />,
+        <ControlMenuSubheader
+          key={`${control.id}-label`}
+          label={control.label}
+        />,
         <ChoiceMenuItem
           key={`${control.id}-default`}
           primary={defaultChoiceLabel(control)}
@@ -550,7 +556,7 @@ function ControlsRow(props: {
         aria-hidden="true"
       >
         {controls.map(control => (
-          <ControlItem
+          <ControlMenu
             key={control.id}
             control={control}
             onSelect={v => onChange(control, v)}
@@ -559,7 +565,7 @@ function ControlsRow(props: {
       </div>
 
       {visible.map(control => (
-        <ControlItem
+        <ControlMenu
           key={control.id}
           control={control}
           onSelect={v => onChange(control, v)}
@@ -578,7 +584,7 @@ function ControlsRow(props: {
           >
             <MoreHorizIcon fontSize="small" />
           </button>
-          <OverflowMenu
+          <OverflowControlsMenu
             controls={overflow}
             anchor={overflowAnchor}
             onClose={() => setOverflowAnchor(null)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.29.7":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/code-frame@npm:7.29.7"
   dependencies:
@@ -2191,6 +2191,9 @@ __metadata:
     "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/testutils": ^4.0.0
+    "@testing-library/dom": ^10.4.0
+    "@testing-library/react": ^16.3.0
+    "@testing-library/user-event": ^14.6.0
     "@types/jest": ^29.2.0
     "@types/json-schema": ^7.0.11
     "@types/react": ^18.0.26
@@ -3676,10 +3679,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^10.4.0":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^5.0.1
+    aria-query: 5.3.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.5.0
+    picocolors: 1.1.1
+    pretty-format: ^27.0.2
+  checksum: 3887fe95594b6d9467a804e2cc82e719c57f4d55d7d9459b72a949b3a8189db40375b89034637326d4be559f115abc6b6bcfcc6fec0591c4a4d4cdde96751a6c
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^16.3.0":
+  version: 16.3.2
+  resolution: "@testing-library/react@npm:16.3.2"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 1f6f4d8374aab54214229eecdd429d5e878e902c6136a48e187a24d4917014bf91ab9aa7fab18c17f6bf05f226fac228ba9a5c1803657129173dd8a062139c17
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.6.0":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 4cb8a81fea1fea83a42619e9545137b51636bb7a3182c596bb468e5664f1e4699a275c2d0fb8b6dcc3fe2684f9d87b0637ab7cb4f566051539146872c9141fcb
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:2":
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: ad8b87e4ad64255db5f0a73bc2b4da9b146c38a3a8ab4d9306154334e0fc67ae64e76bfa298eebd1e71830591fb15987e5de7111bdb36a2221bdc379e3415fb0
   languageName: node
   linkType: hard
 
@@ -4802,6 +4857,15 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: ^2.0.3
+  checksum: 305bd73c76756117b59aba121d08f413c7ff5e80fa1b98e217a3443fcddb9a232ee790e24e432b59ae7625aebcf4c47cb01c2cac872994f0b426f5bdfcd96ba9
   languageName: node
   linkType: hard
 
@@ -6059,6 +6123,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 8679b850e1a3d0ebbc46ee780d5df7b478c23f335887464023a631d1b9af051ad4a6595a44220f9ff8ff95a8ddccf019b5ad778a976fd7bbf77383d36f412f90
+  languageName: node
+  linkType: hard
+
 "detect-newline@npm:^3.0.0":
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
@@ -6088,6 +6159,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
   languageName: node
   linkType: hard
 
@@ -8502,6 +8580,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 1ee98b4580246fd90dd54da6e346fb1caefcf05f677c686d9af237a157fdea3fd7c83a4bc58f858cd5b10a34d27afe0fdcbd0505a47e0590726a873dc8b8f65d
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^4.0.0":
   version: 4.0.0
   resolution: "make-dir@npm:4.0.0"
@@ -9226,7 +9313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
@@ -9412,6 +9499,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: cf610cffcb793885d16f184a62162f2dd0df31642d9a18edf4ca298e909a8fe80bdbf556d5c9573992c102ce8bf948691da91bf9739bee0ffb6e79c8a8a6e088
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -9537,6 +9635,13 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #94, the follow-ups from the #93 review.

## Changes

- Component renames: `ControlItem` to `ControlMenu`, `ControlSubheader` to `ControlMenuSubheader`, `OverflowMenu` to `OverflowControlsMenu`. No behavior changes.
- The menu spec is migrated to React Testing Library: `render` and `userEvent` replace the hand-rolled `act()`/`dispatchEvent` harness and its `IS_REACT_ACT_ENVIRONMENT` setup, and role-and-name queries (`getByRole('menuitem', { name })`) replace text matching. 

#94 also suggested bumping `@types/react` so `React.act` typechecks without a cast. This PR migrates testing to the React Testing Library so the question is moot: nothing in the package references `React.act` anymore as `render` and `userEvent` now handle `act` internally.