### PR TITLE
Make control menu subheaders sticky

### DIFF
--- a/src/__tests__/persona-controls-menus.spec.tsx
+++ b/src/__tests__/persona-controls-menus.spec.tsx
@@ -57,6 +57,10 @@ describe('control menus', () => {
       expect(screen.getByRole('menu').getAttribute('aria-labelledby')).toBe(
         heading().id
       );
+      // Sticky, so the title stays visible while a long option list scrolls.
+      expect(heading().classList.contains('MuiListSubheader-sticky')).toBe(
+        true
+      );
     });
 
     it('focuses the selected row and moves focus with the keyboard', async () => {
@@ -135,8 +139,12 @@ describe('control menus', () => {
       );
       const headings = Array.from(
         document.querySelectorAll(SUBHEADER_SELECTOR)
-      ).map(h => h.textContent);
-      expect(headings).toEqual(['Aaa', 'Bbb']);
+      );
+      expect(headings.map(h => h.textContent)).toEqual(['Aaa', 'Bbb']);
+      // Sticky, so the section a scrolled row belongs to stays visible.
+      for (const h of headings) {
+        expect(h.classList.contains('MuiListSubheader-sticky')).toBe(true);
+      }
       // "A one" is the only selected row; ArrowDown crosses the "Bbb" heading
       // to the next section's first choice row.
       expect(focused()).toBe(screen.getByRole('menuitem', { name: 'A one' }));

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -333,18 +333,17 @@ function defaultChoiceLabel(control: Control): string {
  * The uppercase group label used in control menus: it titles a control's own
  * dropdown and labels each control's section in the overflow menu. Rendered
  * with MUI's `ListSubheader`, which has no tabindex, so arrow-key focus skips
- * it and the menu stays keyboard-navigable.
+ * it and the menu stays keyboard-navigable. Sticky: when the menu scrolls, the
+ * label pins to the top, so the group the visible rows belong to stays
+ * readable; in the overflow menu the next section's label paints over it on
+ * arrival.
  */
 function ControlMenuSubheader(props: {
   label: string;
   id?: string;
 }): JSX.Element {
   return (
-    <ListSubheader
-      id={props.id}
-      disableSticky
-      className={`${MENU_CLASS}-subheader`}
-    >
+    <ListSubheader id={props.id} className={`${MENU_CLASS}-subheader`}>
       {props.label}
     </ListSubheader>
   );

--- a/style/base.css
+++ b/style/base.css
@@ -227,10 +227,14 @@
   background-color: var(--jp-layout-color1);
   border: 1px solid var(--jp-border-color2);
   box-shadow: var(--jp-elevation-z6);
+}
 
-  /* Keep focus-scrolled rows clear of the stuck group label: when arrow keys
-     scroll a row into view at the top, offset it by the label's height so the
-     label does not cover it. */
+/* Keep focus-scrolled rows clear of the stuck group label: when arrow keys
+   scroll a row into view at the top, offset it by the label's height so the
+   label does not cover it. Only menus containing a group label need the
+   offset; the persona picker and usage popover share this paper class and
+   keep edge-aligned scrolling. */
+.jp-jai-controlMenu-paper:has(.jp-jai-controlMenu-subheader) {
   scroll-padding-top: 32px;
 }
 
@@ -286,10 +290,11 @@
 /* Control menu group label: an uppercase heading above a control's choices.
    It titles each control's own dropdown; in the overflow popover a hairline
    divider and top spacing separate the controls' sections. Scoped under the
-   paper to win over MUI's ListSubheader defaults. The labels are sticky
-   (MUI's default, position from its sticky class), so the opaque background
-   is load-bearing: scrolled rows pass beneath it. One line only, so stacked
-   sticky labels in the overflow menu cover each other exactly. */
+   paper to win over MUI's ListSubheader defaults. The labels are sticky:
+   sticky is MUI's ListSubheader default, and its sticky class supplies the
+   positioning. The opaque background is load-bearing, scrolled rows pass
+   beneath it. One line only, so stacked sticky labels in the overflow menu
+   cover each other exactly. */
 .jp-jai-controlMenu-paper .jp-jai-controlMenu-subheader {
   margin-top: 8px;
   padding: 8px 12px 2px;

--- a/style/base.css
+++ b/style/base.css
@@ -281,7 +281,10 @@
 /* Control menu group label: an uppercase heading above a control's choices.
    It titles each control's own dropdown; in the overflow popover a hairline
    divider and top spacing separate the controls' sections. Scoped under the
-   paper to win over MUI's ListSubheader defaults. */
+   paper to win over MUI's ListSubheader defaults. The labels are sticky
+   (MUI's default, position from its sticky class), so the opaque background
+   is load-bearing: scrolled rows pass beneath it. One line only, so stacked
+   sticky labels in the overflow menu cover each other exactly. */
 .jp-jai-controlMenu-paper .jp-jai-controlMenu-subheader {
   margin-top: 8px;
   padding: 8px 12px 2px;
@@ -294,6 +297,9 @@
   text-transform: uppercase;
   color: var(--jp-ui-font-color1);
   background-color: var(--jp-layout-color1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* The first (or only) label sits flush at the top, no divider or extra gap

--- a/style/base.css
+++ b/style/base.css
@@ -227,6 +227,11 @@
   background-color: var(--jp-layout-color1);
   border: 1px solid var(--jp-border-color2);
   box-shadow: var(--jp-elevation-z6);
+
+  /* Keep focus-scrolled rows clear of the stuck group label: when arrow keys
+     scroll a row into view at the top, offset it by the label's height so the
+     label does not cover it. */
+  scroll-padding-top: 32px;
 }
 
 /* stylelint-disable selector-class-pattern -- theming MUI's menu item classes */


### PR DESCRIPTION
Fixes #98 by using MUI's native sticky headers implementation.

## Changes

- `ControlMenuSubheader` no longer sets `disableSticky`, so MUI's sticky positioning applies: a control dropdown keeps its title pinned while a long option list scrolls, and in the overflow menu the label of the topmost visible section stays pinned, with the next section's label taking its place on arrival.
- `style/base.css`: the subheader is clamped to one line (nowrap plus ellipsis) so stacked sticky labels cover each other exactly, and the menu's scroll container gets `scroll-padding-top` so keyboard focus scrolling lands rows below the stuck label instead of underneath it.

## Testing

- Extended the component tests to assert the sticky variant on the heading in both the single-control dropdown and the overflow menu.
- Stress-tested the implementation with a custom persona advertising 2000 models; works well, including keyboard focus jumps (Home, arrows) landing clear of the pinned label.

<img width="1278" height="903" alt="sticky" src="https://github.com/user-attachments/assets/e4c1210c-53e9-4702-a263-b313246cb90f" />


<img width="760" height="860" alt="sticky-overflow-bottom" src="https://github.com/user-attachments/assets/8c063213-5f84-443d-af43-f5f7e40fcf95" />

