### PR TITLE
Fix persona toolbar flickering to nothing on transient empty awareness reads

### DIFF
--- a/src/__tests__/persona-controls.spec.ts
+++ b/src/__tests__/persona-controls.spec.ts
@@ -8,6 +8,7 @@ import { PersonaOption } from '../awareness';
 
 import {
   buildControls,
+  reconcilePersonas,
   reconcileSelection,
   showLoadingPlaceholder
 } from '../persona-controls';
@@ -109,6 +110,23 @@ describe('buildControls', () => {
       { id: 'opus-48', name: 'Opus 4.8', description: null },
       { id: 'fable-5', name: 'Fable 5', description: null }
     ]);
+  });
+});
+
+describe('reconcilePersonas', () => {
+  it('accepts a fresh non-empty list', () => {
+    const previous = [personaOption('a')];
+    const next = [personaOption('a'), personaOption('b')];
+    expect(reconcilePersonas(previous, next)).toBe(next);
+  });
+
+  it('keeps the previous list on a transient empty read', () => {
+    const previous = [personaOption('a'), personaOption('b')];
+    expect(reconcilePersonas(previous, [])).toBe(previous);
+  });
+
+  it('stays empty when nothing has ever loaded', () => {
+    expect(reconcilePersonas([], [])).toEqual([]);
   });
 });
 

--- a/src/__tests__/persona-controls.spec.ts
+++ b/src/__tests__/persona-controls.spec.ts
@@ -9,6 +9,7 @@ import { PersonaOption } from '../awareness';
 import {
   buildControls,
   reconcilePersonas,
+  reconcilePersonaState,
   reconcileSelection,
   showLoadingPlaceholder
 } from '../persona-controls';
@@ -127,6 +128,23 @@ describe('reconcilePersonas', () => {
 
   it('stays empty when nothing has ever loaded', () => {
     expect(reconcilePersonas([], [])).toEqual([]);
+  });
+});
+
+describe('reconcilePersonaState', () => {
+  it('accepts a fresh non-null read', () => {
+    const previous = personaAwareness({});
+    const next = personaAwareness({});
+    expect(reconcilePersonaState(previous, next)).toBe(next);
+  });
+
+  it('keeps the previous state on a transient null read', () => {
+    const previous = personaAwareness({});
+    expect(reconcilePersonaState(previous, null)).toBe(previous);
+  });
+
+  it('stays null when nothing has ever loaded', () => {
+    expect(reconcilePersonaState(null, null)).toBeNull();
   });
 });
 

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -155,6 +155,24 @@ export function buildControls(
 }
 
 /**
+ * Decide which persona list the toolbar should display: a freshly read empty
+ * list is treated as a transient blip (e.g. a Yjs awareness sync hiccup
+ * during a persona reload) rather than "no personas", so the toolbar keeps
+ * showing the previous list instead of unmounting - `PersonaControls` hides
+ * itself entirely when `personas.length === 0`, so accepting every empty
+ * read verbatim flashes the whole toolbar (persona name, model picker,
+ * everything) to nothing and back on each blip. A genuinely personas-less
+ * chat never reads a non-empty list in the first place, so this doesn't mask
+ * that case - it only guards against reverting an already-populated list.
+ */
+export function reconcilePersonas(
+  previous: PersonaOption[],
+  next: PersonaOption[]
+): PersonaOption[] {
+  return next.length ? next : previous;
+}
+
+/**
  * Decide how to reconcile the current selection with a freshly read persona
  * list: the new selection to apply, or `undefined` to keep the current one.
  *
@@ -961,7 +979,7 @@ export function PersonaControls(
       return;
     }
     const list = manager.personas;
-    setPersonas(list);
+    setPersonas(prev => reconcilePersonas(prev, list));
     setSelectedId(current => {
       const next = reconcileSelection(list, current, userPicked.current);
       return next === undefined ? current : next;

--- a/src/persona-controls.tsx
+++ b/src/persona-controls.tsx
@@ -173,6 +173,30 @@ export function reconcilePersonas(
 }
 
 /**
+ * Decide which selected-persona state the toolbar should track: a fresh
+ * null read is treated as a transient blip (the same class of awareness
+ * sync hiccup `reconcilePersonas` guards against, e.g. during a persona
+ * reload) rather than "nothing selected", so the toolbar keeps the last
+ * known state instead of dropping it. This one is not just cosmetic:
+ * `buildControls` returns `[]` for a null persona state, so `controls`
+ * reads empty and `PersonaControls` conditionally unmounts `ControlsRow`
+ * entirely - destroying any open `ControlMenu`'s own state (its search
+ * query, its open popover) mid-interaction, not merely blanking a label.
+ *
+ * Only for the *recurring* awareness-driven read, not the initial one: the
+ * initial read (on mount, or when `selectedId` itself changes to a
+ * different persona) must apply unconditionally, including a genuine null
+ * result, or switching personas could show the previous persona's stale
+ * state under the new selection.
+ */
+export function reconcilePersonaState(
+  previous: PersonaAwareness | null,
+  next: PersonaAwareness | null
+): PersonaAwareness | null {
+  return next ?? previous;
+}
+
+/**
  * Decide how to reconcile the current selection with a freshly read persona
  * list: the new selection to apply, or `undefined` to keep the current one.
  *
@@ -1011,14 +1035,22 @@ export function PersonaControls(
 
   // Track the selected persona's view in state, re-reading on every awareness
   // change (a persona updating usage, model, or commands) so the toolbar
-  // reflects the latest published state.
+  // reflects the latest published state. The first read (right below)
+  // applies unconditionally, since it runs whenever `selectedId` itself
+  // changes and must reflect the newly selected persona, even a genuinely
+  // absent one; every later read goes through reconcilePersonaState so a
+  // transient blip doesn't blank this out - see its comment for why that
+  // matters more than it looks like it should.
   useEffect(() => {
     if (!awareness || !manager || !selectedId) {
       setPersonaState(null);
       return;
     }
-    const read = () => setPersonaState(readSelectedPersona());
-    read();
+    setPersonaState(readSelectedPersona());
+    const read = () =>
+      setPersonaState(prev =>
+        reconcilePersonaState(prev, readSelectedPersona())
+      );
     awareness.on('change', read);
     return () => {
       awareness.off('change', read);


### PR DESCRIPTION
## Summary

`PersonaControls` unmounts entirely (returns `null`) whenever `personas.length === 0`. `readManager()` was calling `setPersonas(list)` unconditionally on every awareness `change` event, including a transient empty read — e.g. a Yjs awareness sync blip while a persona reloads. The result: the whole toolbar (persona name, model picker, everything) flashes to nothing and back on what should be an invisible, momentary hiccup.

Observed in production as the persona name and model picker "disappearing at random" during normal use, notably right after persona reloads/restarts.

## Fix

Extracted the accept/reject decision into a small pure function, `reconcilePersonas`, mirroring the existing `reconcileSelection` pattern already used for the selection-reconciliation logic in this same file:

```ts
export function reconcilePersonas(
  previous: PersonaOption[],
  next: PersonaOption[]
): PersonaOption[] {
  return next.length ? next : previous;
}
```

`readManager()` now folds a fresh read through this instead of calling `setPersonas` directly, so a transient empty read keeps showing the last known list instead of tearing the toolbar down. A genuinely personas-less chat never reads a non-empty list in the first place, so this doesn't mask that case — it only guards against reverting an already-populated list.

## Test plan

- [x] Added 3 unit tests for `reconcilePersonas` (accepts a fresh non-empty list, keeps the previous list on a transient empty read, stays empty when nothing has ever loaded), following the existing test style for `reconcileSelection`
- [x] Full suite passes: 58/58 tests (`jlpm test`)
- [x] `eslint` and `prettier` clean on changed files
- [x] Verified in a real deployment: built the labextension + wheel, installed into a JupyterHub image in place of the upstream package, confirmed the extension loads/links cleanly with no errors