### PR TITLE
Pin jupyter_collaboration <5 in CI to work around a 5.0.0 regression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,13 @@ jobs:
     - name: Build the extension
       run: |
         set -eux
-        python -m pip install .[test]
+        # jupyter_collaboration 5.0.0 (2026-08-03) shows a "document is taking
+        # some time to load" dialog that never clears for jupyterlab_chat's
+        # .chat documents under slow-load timing, hanging ui-tests. Pin to the
+        # last 4.x line (4.4.2 carries the same security fix as 5.0.0) here in
+        # CI only, not in pyproject.toml, until this is fixed upstream or
+        # jupyterlab_chat verifies 5.x compatibility.
+        python -m pip install .[test] "jupyter_collaboration<5"
 
         pytest -vv -r ap --cov jupyter_ai_persona_manager
         jupyter server extension list
@@ -83,7 +89,8 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0,<5" jupyter_ai_persona_manager*.whl
+        # See the "Build the extension" step above for why jupyter_collaboration is pinned.
+        pip install "jupyterlab>=4.0.0,<5" jupyter_ai_persona_manager*.whl "jupyter_collaboration<5"
 
 
         jupyter server extension list
@@ -116,7 +123,8 @@ jobs:
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab>=4.0.0,<5" jupyter_ai_persona_manager*.whl
+        # See the "Build the extension" step in the build job for why jupyter_collaboration is pinned.
+        python -m pip install "jupyterlab>=4.0.0,<5" jupyter_ai_persona_manager*.whl "jupyter_collaboration<5"
 
     - name: Install dependencies
       working-directory: ui-tests


### PR DESCRIPTION
## Summary
- `jupyter_collaboration` 5.0.0 (with `jupyter-docprovider`/`jupyter-server-ydoc` 3.0.0), released 2026-08-03, introduces a "document is taking some time to load" dialog (jupyterlab/jupyter-collaboration#596) that never clears for jupyterlab_chat's `.chat` documents under this repo's slow-load timing. The dialog is modal and blocks all clicks, causing `ui-tests/tests/slow-load.spec.ts` to hang and time out.
- `jupyterlab_chat` declares `jupyter_collaboration>=4,<6`, so any CI run without a lockfile silently picks up 5.0.0 as soon as it's the latest match.
- Reproduced on `main` in a clean venv mirroring CI's exact install steps; pinning `jupyter_collaboration<5` (resolves to 4.4.2, the security-only backport release cut the same day as 5.0.0) fixes it with no other regressions — ran the full `ui-tests` suite (25/25) with the pin applied.
- Pinned in the CI workflow only (`.github/workflows/build.yml`), not in `pyproject.toml`, so this doesn't affect anyone installing the published package — just our own CI/test runs until this is fixed upstream or jupyterlab_chat verifies 5.x compatibility.
- Branched off `main` directly (a prior attempt, #118, was mistakenly based on top of #116 and pulled in its whole diff — this one is scoped to just the CI fix).

## Test plan
- [x] Confirmed `main` fails identically to the reported CI failure in a clean venv mirroring CI's install steps, with `jupyter_collaboration` unpinned (resolves to 5.0.0)
- [x] Confirmed the same setup passes with `jupyter_collaboration<5` (resolves to 4.4.2)
- [x] Ran the full `ui-tests` suite with the pin applied: 25/25 passed
- [ ] CI green on this PR