### PR TITLE
Group Dependabot npm updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    # `schedule.interval` is required but inert here since routine version
+    # updates are disabled below; security updates run off Dependabot alerts.
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/ui-tests"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` configuring security-only grouping for the npm ecosystem (root and `/ui-tests`). Routine version-update PRs are disabled (`open-pull-requests-limit: 0`); security updates continue to run off Dependabot alerts, now grouped into a single PR per directory instead of one PR per dependency.