### PR TITLE
Resolve attachments via dataclass attribute access

### DIFF
--- a/jupyter_ai_persona_manager/base_persona.py
+++ b/jupyter_ai_persona_manager/base_persona.py
@@ -784,19 +784,17 @@ class BasePersona(ABC, LoggingConfigurable, metaclass=ABCLoggingConfigurableMeta
         try:
             attachment_data = self.chat.get_attachments().get(attachment_id)
 
-            if attachment_data and isinstance(attachment_data, dict):
-                # If attachment has a 'value' field with filename
-                if "value" in attachment_data:
-                    filename = attachment_data["value"]
+            # attachment_data is a FileAttachment/NotebookAttachment dataclass
+            filename = getattr(attachment_data, "value", None)
+            if filename:
+                # Try relative to workspace directory
+                workspace_path = os.path.join(self.get_workspace_dir(), filename)
+                if os.path.exists(workspace_path):
+                    return workspace_path
 
-                    # Try relative to workspace directory
-                    workspace_path = os.path.join(self.get_workspace_dir(), filename)
-                    if os.path.exists(workspace_path):
-                        return workspace_path
-
-                    # Try as absolute path
-                    if os.path.exists(filename):
-                        return filename
+                # Try as absolute path
+                if os.path.exists(filename):
+                    return filename
 
             return None
 


### PR DESCRIPTION
`jupyterlab-chat 0.25.0a1` changed `BaseChatModel.get_attachments()` to return FileAttachment / NotebookAttachment dataclasses instead of raw dicts. `resolve_attachment_to_path()` still guarded on isinstance(attachment_data, dict), which is now always False, so it returned None and non-ACP personas could no longer resolve attachments to file paths.
  
  Fix:
  Read the filename via attribute access